### PR TITLE
Add Python samples for security score and driver/firmware patching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,9 @@ obj/
 /language-examples/go/license
 /language-examples/go/download_token.txt
 /language-examples/go/pass_key.txt
-/eval-license/download_token.txt
-/eval-license/pass_key.txt
+# eval-license — license secrets, never commit (keep only the README)
+/eval-license/*
+!/eval-license/README.md
 /catalog-scripts/AppCentricFile/FindCVE/download_token.txt
 /catalog-scripts/AppCentricFile/FindCVE/results_CVE-2008-4434_20251009_151048.txt
 /catalog-scripts/AppCentricFile/FindCVE/results_CVE-2008-4434_20251010_154046.txt

--- a/helloworld/python/README.md
+++ b/helloworld/python/README.md
@@ -80,7 +80,10 @@ Python 3.7 or later is required. No third-party packages are needed — all depe
 ├── detect_products.py      # List all installed applications on the endpoint
 ├── product_detail.py       # Full detail report for a single product by signature ID
 ├── patch_status.py         # Missing and installed patches for all patch management agents
-└── uninstall_product.py    # Uninstall a product by signature ID
+├── uninstall_product.py    # Uninstall a product by signature ID
+├── security_score.py       # OPSWAT device security score with per-category breakdown
+├── collect_device_inventory.py     # Collect system/OS/BIOS/device inventory (Windows only)
+└── detect_driver_firmware_patches.py  # Detect driver/firmware patches (Windows only)
 ```
 
 ---
@@ -310,6 +313,81 @@ Run detect_products.py to list all installed products and their signature IDs.
 **SDK methods used:**
 - `3` — GetProductInfo (with `run_detection=True`)
 - `50303` — UninstallProduct
+
+---
+
+### `security_score.py`
+
+Calculates the OPSWAT device security score and prints the overall score plus a per-category breakdown (Anti Malware, Antiphishing, Patch Management, Vulnerabilities, Encryption, Firewall, Backup, Unwanted Apps). Loads the offline CVE database first so the Vulnerabilities category is scored against real CVE data. Writes the full result to `security_score.json`.
+
+```bash
+python security_score.py            # force a fresh refresh (default)
+python security_score.py cached     # use cached values, no refresh
+```
+
+> The overall `score_status` reflects the **weakest** category, so a single `poor` category reports the device as `poor` even when the numeric total is high.
+
+**SDK methods used:**
+- `50520` — ConsumeOfflineVmodDatabase (so the Vulnerabilities category has CVE data)
+- `111` — GetSecurityScore
+
+**Output:**
+```
+  Total Score   : 90 / 100
+  Score Status  : poor
+
+  Anti Malware              30/30       good
+  Vulnerabilities           0/10        poor
+  Firewall                  10/10       good
+```
+
+---
+
+### `collect_device_inventory.py`
+
+> **Windows only.** Requires a license that entitles the driver/firmware feature.
+
+Collects endpoint inventory data (system, OS, BIOS, and hardware devices) used for driver/firmware patch matching. Prints a summary with a per-device-class count and writes the full inventory to `device_inventory.json` (or a custom path).
+
+```bash
+python collect_device_inventory.py                 # writes device_inventory.json
+python collect_device_inventory.py D:\inv.json     # custom output path
+```
+
+**SDK methods used:**
+- `50900` — LoadDriverFirmwareDatabase (initializes the driver/firmware vmod; uses `patch_driver_firmware.dat`)
+- `50901` — CollectDeviceInventory
+
+**Output:**
+```
+  System
+    Vendor        : Dell Inc.
+    Product Name  : Latitude 5450
+
+  Devices: 305 detected
+    Net                       16
+    USB                       16
+    Firmware                  2
+```
+
+---
+
+### `detect_driver_firmware_patches.py`
+
+> **Windows only.** Requires a license that entitles the driver/firmware feature.
+
+Detects applicable driver/firmware patches by matching the device inventory against the loaded driver/firmware database. Maps each patch's `reboot_required` code to a label and preserves the full `download_urls` array (URLs + SHA1/256/512/MD5 + size) in `driver_firmware_patches.json`. Optionally accepts a prebuilt inventory file from `collect_device_inventory.py`.
+
+```bash
+python detect_driver_firmware_patches.py                      # collect inventory internally
+python detect_driver_firmware_patches.py device_inventory.json  # use a prebuilt inventory
+```
+
+> If the device model is not in the loaded catalog the SDK returns `WA_VMOD_ERROR_MODEL_NOT_SUPPORTED` (rc `-1067`); the script reports this as a clean "no coverage" result rather than failing.
+
+**SDK methods used:**
+- `50900` — LoadDriverFirmwareDatabase
+- `50902` — DetectDriverFirmwarePatches
 
 ---
 

--- a/helloworld/python/collect_device_inventory.py
+++ b/helloworld/python/collect_device_inventory.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+###############################################################################################
+##  Sample Code for Collect Device Inventory  (Windows only)
+##  Reference Implementation using OESIS Framework
+##
+##  Collects endpoint inventory data (system, OS, BIOS, and hardware devices) used for
+##  driver/firmware patch matching via CollectDeviceInventory (method 50901). Prints a
+##  summary to the console and writes the full inventory to a JSON output file.
+##
+##  Usage:
+##      python collect_device_inventory.py                 # writes device_inventory.json
+##      python collect_device_inventory.py <output_file>   # custom output path
+##
+##  CollectDeviceInventory returns inventory_collection grouped into:
+##      system   -- vendor, system_family, system_product_name, system_sku, machine_type
+##      os       -- os_name, os_version, architecture, build
+##      bios     -- bios_vendor, bios_version, release_date
+##      devices  -- list of detected hardware devices (driver/firmware metadata)
+##
+##  https://software.opswat.com/OESIS_V4/html/c_method.html -> method 50901
+##
+##  Created by Chris Seiler
+##  OPSWAT OEM Solutions Architect
+###############################################################################################
+
+import json
+import os
+import sys
+
+from sdk_wrapper import OESISWrapper, SDKError
+from platform_utils import validate_sdk_environment
+from platform_utils import get_lib_filename
+from platform_utils import get_os_type, OS_TYPE_WINDOWS
+
+# Hardcoded SDK directory relative to this script
+SDK_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sdk")
+
+# Driver/firmware metadata database filename (the only file currently accepted by method 50900)
+DRIVER_FIRMWARE_DB = "patch_driver_firmware.dat"
+
+
+def find_driver_firmware_db():
+    # Locate patch_driver_firmware.dat. It is not staged into sdk/ by
+    # copy_sdk_files.py, so fall back to the SDK Downloader's extract location:
+    #   <repo_root>/OPSWAT-SDK/extract/analog/client/patch_driver_firmware.dat
+    # The repo root is found by walking up for the 'sdkroot' marker file.
+    local = os.path.join(SDK_DIR, DRIVER_FIRMWARE_DB)
+    if os.path.isfile(local):
+        return local
+
+    current = os.path.dirname(os.path.abspath(__file__))
+    while True:
+        if os.path.isfile(os.path.join(current, "sdkroot")):
+            candidate = os.path.join(
+                current, "OPSWAT-SDK", "extract", "analog", "client", DRIVER_FIRMWARE_DB
+            )
+            if os.path.isfile(candidate):
+                return candidate
+            break
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
+
+    return None
+
+
+def initialize_framework():
+    # Load the SDK and initialize with the pass_key.txt in the sdk directory
+    # https://software.opswat.com/OESIS_V4/html/c_sdk.html
+    pass_key_path = os.path.join(SDK_DIR, "pass_key.txt")
+
+    if not os.path.isfile(pass_key_path):
+        print("Could not find pass_key.txt. Make sure the license is in the sdk directory.")
+        raise Exception("License pass_key.txt file not found")
+
+    sdk = OESISWrapper(os.path.join(SDK_DIR, get_lib_filename()))
+    sdk.load()
+    sdk.setup(os.path.join(SDK_DIR, "license.cfg"), pass_key_path)
+    return sdk
+
+
+def load_driver_firmware_database(sdk, db_path):
+    # Load the driver/firmware metadata database. This initializes the
+    # driver/firmware vmod component; without it CollectDeviceInventory and
+    # DetectDriverFirmwarePatches fail with rc=-5 (WAAPI_ERROR_NOT_INITIALIZED).
+    # https://software.opswat.com/OESIS_V4/html/c_method.html -> method 50900
+    rc, result = sdk.invoke(50900, input_path=db_path)
+    if rc < 0:
+        raise Exception(f"LoadDriverFirmwareDatabase failed (rc={rc}): {result}")
+    return result.get("result", {})
+
+
+def collect_device_inventory(sdk, output_file):
+    # Collect endpoint inventory and export it to output_file.
+    # output_file accepts absolute or relative paths; if omitted entirely the
+    # inventory is only returned in the response and not persisted to disk.
+    # https://software.opswat.com/OESIS_V4/html/c_method.html -> method 50901
+    rc, result = sdk.invoke(50901, output_file=output_file)
+    if rc < 0:
+        raise Exception(f"CollectDeviceInventory failed (rc={rc}): {result}")
+    return result.get("result", {})
+
+
+def print_inventory_report(result):
+    # Print a human-readable summary of the collected inventory.
+    inv     = result.get("inventory_collection", {})
+    system  = inv.get("system", {})
+    os_info = inv.get("os", {})
+    bios    = inv.get("bios", {})
+    devices = inv.get("devices", [])
+
+    print(f"\n  Device Inventory")
+    print("-" * 60)
+
+    print("  System")
+    print(f"    Vendor        : {system.get('vendor', 'Unknown')}")
+    print(f"    Family        : {system.get('system_family', 'Unknown')}")
+    print(f"    Product Name  : {system.get('system_product_name', 'Unknown')}")
+    print(f"    SKU           : {system.get('system_sku', 'Unknown')}")
+    print(f"    Machine Type  : {system.get('machine_type', 'Unknown')}")
+
+    print("\n  Operating System")
+    print(f"    Name          : {os_info.get('os_name', 'Unknown')}")
+    print(f"    Version       : {os_info.get('os_version', 'Unknown')}")
+    print(f"    Architecture  : {os_info.get('architecture', 'Unknown')}")
+    print(f"    Build         : {os_info.get('build', 'Unknown')}")
+
+    print("\n  BIOS")
+    print(f"    Vendor        : {bios.get('bios_vendor', 'Unknown')}")
+    print(f"    Version       : {bios.get('bios_version', 'Unknown')}")
+    print(f"    Release Date  : {bios.get('release_date', 'Unknown')}")
+
+    # Summarise devices: total count plus a count per setup class
+    print(f"\n  Devices: {len(devices)} detected")
+    if devices:
+        class_counts = {}
+        for d in devices:
+            cls = d.get("class", "Unknown") or "Unknown"
+            class_counts[cls] = class_counts.get(cls, 0) + 1
+
+        print("-" * 60)
+        for cls in sorted(class_counts):
+            print(f"    {cls:<24}  {class_counts[cls]}")
+
+
+def main(output_file=None):
+    # Accept an optional output path; default to device_inventory.json in cwd
+    if len(sys.argv) > 1:
+        output_file = sys.argv[1]
+    if not output_file:
+        output_file = os.path.join(os.getcwd(), "device_inventory.json")
+
+    # CollectDeviceInventory is a Windows-only method
+    if get_os_type() != OS_TYPE_WINDOWS:
+        print("CollectDeviceInventory (method 50901) is supported on Windows only.")
+        return
+
+    if not validate_sdk_environment(SDK_DIR):
+        return
+
+    # Locate the driver/firmware database required to initialize the vmod component
+    db_path = find_driver_firmware_db()
+    if not db_path:
+        print(f"ERROR: {DRIVER_FIRMWARE_DB} not found in {SDK_DIR} or under "
+              f"OPSWAT-SDK/extract/analog/client.")
+        print("       Run the SDK Downloader to populate the driver/firmware database.")
+        return
+
+    sdk = None
+    try:
+        sdk = initialize_framework()
+
+        # Driver/firmware vmod must be initialized before collecting inventory
+        print(f"Loading driver/firmware database: {os.path.basename(db_path)}")
+        load_driver_firmware_database(sdk, db_path)
+
+        print(f"\nCollecting device inventory...")
+        result = collect_device_inventory(sdk, output_file)
+
+        print_inventory_report(result)
+
+        # The SDK writes the inventory to output_file; echo where it landed.
+        inventory_file = result.get("inventory_file", output_file)
+        print(f"\n  Inventory exported by SDK to: {inventory_file}")
+
+    except Exception as e:
+        print(f"Received an Exception: {e}")
+    finally:
+        if sdk:
+            try:
+                sdk.teardown()
+            except SDKError:
+                pass
+
+
+if __name__ == "__main__":
+    main()

--- a/helloworld/python/copy_sdk_files.py
+++ b/helloworld/python/copy_sdk_files.py
@@ -91,6 +91,26 @@ def copy_files(src_dir, dst_dir, label):
             print(f"  Copied {filename}")
 
 
+def copy_driver_firmware_db(src_file, dst_dir):
+    """Copy the driver/firmware database into dst_dir if it is present.
+
+    patch_driver_firmware.dat is produced by the SDK Downloader under
+    OPSWAT-SDK/extract/analog/client and is required by the Windows-only
+    CollectDeviceInventory / DetectDriverFirmwarePatches samples. It is not
+    part of the client binaries, so it is copied separately and treated as
+    optional (only present after the analog data has been downloaded).
+    """
+    if not os.path.isfile(src_file):
+        print(f"Driver/firmware database not found (skipping): {src_file}")
+        return
+
+    os.makedirs(dst_dir, exist_ok=True)
+    dst = os.path.join(dst_dir, os.path.basename(src_file))
+    print(f"Copying driver/firmware database:\n  {src_file}\n  -> {dst}")
+    shutil.copy2(src_file, dst)
+    print(f"  Copied {os.path.basename(src_file)}")
+
+
 def copy_analog_files(src_dir, dst_dir):
     """Recursively copy the analog moby directory tree into dst_dir."""
     if not os.path.isdir(src_dir):
@@ -135,6 +155,11 @@ def main():
 
     license_src = os.path.join(repo_root, "eval-license")
 
+    # Driver/firmware database source path (lives alongside the analog client data)
+    driver_firmware_db_src = os.path.join(
+        repo_root, "OPSWAT-SDK", "extract", "analog", "client", "patch_driver_firmware.dat"
+    )
+
     # Analog moby source path (Windows-only, path is fixed per spec)
     analog_src = os.path.join(
         repo_root, "OPSWAT-SDK", "extract", "analog", "client",
@@ -151,6 +176,8 @@ def main():
     try:
         copy_files(sdk_src,     sdk_dst, "SDK binaries")
         copy_files(license_src, sdk_dst, "license files")
+        # Driver/firmware database (optional — only present after analog download)
+        copy_driver_firmware_db(driver_firmware_db_src, sdk_dst)
         print(f"\nDone. SDK ready at: {sdk_dst}")
     except FileNotFoundError as e:
         print(f"ERROR: {e}")

--- a/helloworld/python/detect_driver_firmware_patches.py
+++ b/helloworld/python/detect_driver_firmware_patches.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+###############################################################################################
+##  Sample Code for Detect Driver/Firmware Patches  (Windows only)
+##  Reference Implementation using OESIS Framework
+##
+##  Detects applicable driver/firmware patches by matching the device inventory against the
+##  loaded driver/firmware database via DetectDriverFirmwarePatches (method 50902). Prints a
+##  summary to the console and writes the full patch list to a JSON output file.
+##
+##  Usage:
+##      python detect_driver_firmware_patches.py                 # all components/categories
+##      python detect_driver_firmware_patches.py <inventory.json>  # use a prebuilt inventory
+##
+##  Flow (driver/firmware patch management is Windows only and licensed):
+##      setup -> LoadDriverFirmwareDatabase (50900) -> DetectDriverFirmwarePatches (50902)
+##
+##  If 50900/50902 return rc=-5 (WAAPI_ERROR_NOT_INITIALIZED), the active license does not
+##  entitle the driver/firmware feature -- verify the license, not the script.
+##
+##  https://software.opswat.com/OESIS_V4/html/c_method.html -> methods 50900, 50902
+##
+##  Created by Chris Seiler
+##  OPSWAT OEM Solutions Architect
+###############################################################################################
+
+import json
+import os
+import sys
+
+from sdk_wrapper import OESISWrapper, SDKError
+from platform_utils import validate_sdk_environment
+from platform_utils import get_lib_filename
+from platform_utils import get_os_type, OS_TYPE_WINDOWS
+
+# Hardcoded SDK directory relative to this script
+SDK_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sdk")
+
+# Driver/firmware metadata database filename (the only file currently accepted by method 50900)
+DRIVER_FIRMWARE_DB = "patch_driver_firmware.dat"
+
+# Returned by method 50902 when the detected device model has no entries in the
+# loaded driver/firmware database -- a coverage gap, not an error in the call.
+MODEL_NOT_SUPPORTED = -1067   # WA_VMOD_ERROR_MODEL_NOT_SUPPORTED
+
+# Human-readable labels for the patches[].reboot_required field
+REBOOT_LABELS = {
+    -1: "Unknown",
+     0: "No reboot",
+     1: "Requires reboot",
+     2: "Forces reboot",
+     3: "Forces shutdown",
+     4: "Delayed forced reboot",
+}
+
+
+def find_driver_firmware_db():
+    # Locate patch_driver_firmware.dat. It is not staged into sdk/ by
+    # copy_sdk_files.py, so fall back to the SDK Downloader's extract location:
+    #   <repo_root>/OPSWAT-SDK/extract/analog/client/patch_driver_firmware.dat
+    # The repo root is found by walking up for the 'sdkroot' marker file.
+    local = os.path.join(SDK_DIR, DRIVER_FIRMWARE_DB)
+    if os.path.isfile(local):
+        return local
+
+    current = os.path.dirname(os.path.abspath(__file__))
+    while True:
+        if os.path.isfile(os.path.join(current, "sdkroot")):
+            candidate = os.path.join(
+                current, "OPSWAT-SDK", "extract", "analog", "client", DRIVER_FIRMWARE_DB
+            )
+            if os.path.isfile(candidate):
+                return candidate
+            break
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
+
+    return None
+
+
+def initialize_framework():
+    # Load the SDK and initialize with the pass_key.txt in the sdk directory
+    # https://software.opswat.com/OESIS_V4/html/c_sdk.html
+    pass_key_path = os.path.join(SDK_DIR, "pass_key.txt")
+
+    if not os.path.isfile(pass_key_path):
+        print("Could not find pass_key.txt. Make sure the license is in the sdk directory.")
+        raise Exception("License pass_key.txt file not found")
+
+    sdk = OESISWrapper(os.path.join(SDK_DIR, get_lib_filename()))
+    sdk.load()
+    sdk.setup(os.path.join(SDK_DIR, "license.cfg"), pass_key_path)
+    return sdk
+
+
+def load_driver_firmware_database(sdk, db_path):
+    # Load the driver/firmware metadata database. This initializes the
+    # driver/firmware vmod component; without it DetectDriverFirmwarePatches
+    # fails with rc=-5 (WAAPI_ERROR_NOT_INITIALIZED).
+    # https://software.opswat.com/OESIS_V4/html/c_method.html -> method 50900
+    rc, result = sdk.invoke(50900, input_path=db_path)
+    if rc < 0:
+        raise Exception(f"LoadDriverFirmwareDatabase failed (rc={rc}): {result}")
+    return result.get("result", {})
+
+
+def detect_driver_firmware_patches(sdk, inventory_file=None):
+    # Detect applicable driver/firmware patches by matching system inventory
+    # against the loaded driver/firmware database. With no inventory_file the
+    # engine collects inventory internally. Omitting components/categories
+    # returns all applicable patches.
+    # https://software.opswat.com/OESIS_V4/html/c_method.html -> method 50902
+    params = {}
+    if inventory_file:
+        params["inventory_file"] = inventory_file
+
+    rc, result = sdk.invoke(50902, **params)
+    # MODEL_NOT_SUPPORTED means the catalog has no data for this device model;
+    # surface it as a clean "no coverage" outcome rather than a hard failure.
+    if rc < 0 and rc != MODEL_NOT_SUPPORTED:
+        raise Exception(f"DetectDriverFirmwarePatches failed (rc={rc}): {result}")
+    return rc, result.get("result", {})
+
+
+def format_patch_list(raw_patches):
+    # Extract the fields relevant for display from each raw patch record.
+    # The first download URL's size is surfaced for the console table; the
+    # full download_urls array (with hashes) is preserved for the JSON output.
+    patches = []
+    for p in raw_patches or []:
+        downloads = p.get("download_urls", []) or []
+        first     = downloads[0] if downloads else {}
+        reboot    = p.get("reboot_required", -1)
+        patches.append({
+            "patch_id":        p.get("patch_id"),
+            "title":           p.get("title",     "Unknown"),
+            "component":       p.get("component", "Unknown"),
+            "category":        p.get("category",  "Unknown"),
+            "severity":        p.get("severity",  "Unknown"),
+            "current_version": p.get("current_version", ""),
+            "target_version":  p.get("target_version",  ""),
+            "reboot_required": reboot,
+            "reboot_label":    REBOOT_LABELS.get(reboot, "Unknown"),
+            "size":            first.get("size", 0),
+            "download_urls":   downloads,
+        })
+    return patches
+
+
+def main(inventory_file=None):
+    # Accept an optional prebuilt inventory JSON (from collect_device_inventory.py)
+    if len(sys.argv) > 1:
+        inventory_file = sys.argv[1]
+        if not os.path.isfile(inventory_file):
+            print(f"Inventory file not found: {inventory_file}")
+            return
+
+    # DetectDriverFirmwarePatches is a Windows-only method
+    if get_os_type() != OS_TYPE_WINDOWS:
+        print("DetectDriverFirmwarePatches (method 50902) is supported on Windows only.")
+        return
+
+    if not validate_sdk_environment(SDK_DIR):
+        return
+
+    # Locate the driver/firmware database required to initialize the vmod component
+    db_path = find_driver_firmware_db()
+    if not db_path:
+        print(f"ERROR: {DRIVER_FIRMWARE_DB} not found in {SDK_DIR} or under "
+              f"OPSWAT-SDK/extract/analog/client.")
+        print("       Run the SDK Downloader to populate the driver/firmware database.")
+        return
+
+    sdk = None
+    try:
+        sdk = initialize_framework()
+
+        # Driver/firmware vmod must be initialized before detecting patches
+        print(f"Loading driver/firmware database: {os.path.basename(db_path)}")
+        load_result = load_driver_firmware_database(sdk, db_path)
+        for f in load_result.get("loaded_files", []) or []:
+            print(f"  Loaded: {f.get('file_name', '?')}  "
+                  f"(version={f.get('version', '?')}, "
+                  f"published={f.get('published_epoch', '?')})")
+
+        print(f"\nDetecting applicable driver/firmware patches...")
+        rc, detect_result = detect_driver_firmware_patches(sdk, inventory_file)
+        detected_vendor   = detect_result.get("detected_vendor", "")
+        patches           = sorted(format_patch_list(detect_result.get("patches", [])),
+                                   key=lambda p: (p["title"] or "").lower())
+
+        print("-" * 78)
+        if detected_vendor:
+            print(f"  Detected vendor: {detected_vendor}")
+
+        if rc == MODEL_NOT_SUPPORTED:
+            print("  This device model is not covered by the loaded driver/firmware catalog")
+            print("  (WA_VMOD_ERROR_MODEL_NOT_SUPPORTED). No patches can be matched -- the")
+            print("  catalog currently supports a limited set of vendor models.")
+        elif not patches:
+            print("  No applicable patches found -- all detected drivers/firmware are current.")
+        else:
+            # Print a formatted table to the console
+            for p in patches:
+                title  = (p["title"]           or "Unknown")[:38]
+                comp   = (p["component"]        or "Unknown")[:14]
+                sev    = (p["severity"]         or "Unknown")[:9]
+                cur    = (p["current_version"]  or "?")[:12]
+                tgt    = (p["target_version"]   or "?")[:12]
+                reboot = (p["reboot_label"]     or "Unknown")[:18]
+                print(f"  {title:<38}  {comp:<14}  {sev:<9}  {cur:>12} -> {tgt:<12}  {reboot}")
+
+        print(f"\n  Total: {len(patches)} patch(es) applicable")
+
+        # Write full results to a JSON output file
+        output = {
+            "status":          "model_not_supported" if rc == MODEL_NOT_SUPPORTED else "ok",
+            "detected_vendor": detected_vendor,
+            "loaded_files":    load_result.get("loaded_files", []),
+            "total":           len(patches),
+            "patches":         patches,
+        }
+        output_file = os.path.join(os.getcwd(), "driver_firmware_patches.json")
+        with open(output_file, "w", encoding="utf-8") as f:
+            json.dump(output, f, indent=2, default=str)
+        print(f"\n  Full results written to: {output_file}")
+
+    except Exception as e:
+        print(f"Received an Exception: {e}")
+    finally:
+        if sdk:
+            try:
+                sdk.teardown()
+            except SDKError:
+                pass
+
+
+if __name__ == "__main__":
+    main()

--- a/helloworld/python/security_score.py
+++ b/helloworld/python/security_score.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+###############################################################################################
+##  Sample Code for Security Score
+##  Reference Implementation using OESIS Framework
+##
+##  Calculates and prints the OPSWAT Security Score for this device using
+##  GetSecurityScore (method 111). Prints the overall score and a per-category
+##  breakdown to the console and writes the full result to a JSON output file.
+##
+##  Usage:
+##      python security_score.py            # force a fresh refresh (default)
+##      python security_score.py cached     # use cached values, no refresh
+##
+##  GetSecurityScore returns:
+##      total_score   -- overall device security score (0-100)
+##      score_status  -- 'good', 'warning', or 'poor'
+##      categories[]  -- per-category score, max_score, status, and details
+##
+##  https://software.opswat.com/OESIS_V4/html/c_method.html -> method 111
+##
+##  Created by Chris Seiler
+##  OPSWAT OEM Solutions Architect
+###############################################################################################
+
+import json
+import os
+import sys
+
+from sdk_wrapper import OESISWrapper, SDKError
+from platform_utils import validate_sdk_environment
+from platform_utils import get_lib_filename
+
+# Hardcoded SDK directory relative to this script
+SDK_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sdk")
+
+
+def initialize_framework():
+    # Load the SDK and initialize with the pass_key.txt in the sdk directory
+    # https://software.opswat.com/OESIS_V4/html/c_sdk.html
+    pass_key_path = os.path.join(SDK_DIR, "pass_key.txt")
+
+    if not os.path.isfile(pass_key_path):
+        print("Could not find pass_key.txt. Make sure the license is in the sdk directory.")
+        raise Exception("License pass_key.txt file not found")
+
+    sdk = OESISWrapper(os.path.join(SDK_DIR, get_lib_filename()))
+    sdk.load()
+    sdk.setup(os.path.join(SDK_DIR, "license.cfg"), pass_key_path)
+    return sdk
+
+
+def consume_offline_vmod_database(sdk, database_file):
+    # Loads the offline CVE vulnerability database (v2mod.dat) into the SDK so the
+    # Vulnerabilities category of the security score can be evaluated offline.
+    # Without this, the Vulnerabilities category reports 0 / poor.
+    # https://software.opswat.com/OESIS_V4/html/c_method.html -> method 50520
+    rc, result = sdk.invoke(50520, dat_input_source_file=database_file)
+    if rc < 0:
+        raise Exception(f"ConsumeOfflineVmodDatabase failed (rc={rc}): {result}")
+
+
+def get_security_score(sdk, force_refresh=True):
+    # Calculate and return the OPSWAT Security Score for the device.
+    # force_refresh=True makes fresh API calls; False uses cached values.
+    # https://software.opswat.com/OESIS_V4/html/c_method.html -> method 111
+    rc, result = sdk.invoke(111, force_refresh=force_refresh)
+    if rc < 0:
+        raise Exception(f"GetSecurityScore failed (rc={rc}): {result}")
+    return result.get("result", {})
+
+
+def print_score_report(score):
+    # Print the overall score and a per-category breakdown to the console.
+    total      = score.get("total_score", "Unknown")
+    status     = score.get("score_status", "Unknown")
+    cache_ok   = score.get("cache_valid")
+    timestamp  = score.get("timestamp", "Unknown")
+
+    print(f"\n  OPSWAT Security Score")
+    print("-" * 60)
+    print(f"  Total Score   : {total} / 100")
+    print(f"  Score Status  : {status}")
+    print(f"  Timestamp     : {timestamp}")
+    print(f"  Cache Valid   : {cache_ok}")
+
+    categories = score.get("categories", [])
+    if not categories:
+        print("\n  No category breakdown returned.")
+        return
+
+    print(f"\n  Category Breakdown")
+    print("-" * 60)
+    for c in categories:
+        # Friendly label from the raw category name (e.g. anti_malware -> Anti Malware)
+        name      = c.get("name", "unknown").replace("_", " ").title()
+        score_val = c.get("score", 0)
+        max_val   = c.get("max_score", 0)
+        cat_status = c.get("status", "unknown")
+        print(f"  {name:<24}  {str(score_val) + '/' + str(max_val):<10}  {cat_status}")
+
+
+def main(force_refresh=True):
+    # Accept an optional "cached" argument to skip the refresh and use cached values
+    if len(sys.argv) > 1:
+        if sys.argv[1].lower() == "cached":
+            force_refresh = False
+        else:
+            print(f"Invalid argument '{sys.argv[1]}'.")
+            print("Usage: python security_score.py [cached]   (default: force refresh)")
+            return
+
+    if not validate_sdk_environment(SDK_DIR):
+        return
+
+    sdk = None
+    try:
+        sdk = initialize_framework()
+
+        # Load the offline vulnerability database (v2mod.dat) so the
+        # Vulnerabilities category is scored against real CVE data.
+        consume_offline_vmod_database(sdk, os.path.join(SDK_DIR, "v2mod.dat"))
+
+        mode = "fresh refresh" if force_refresh else "cached values"
+        print(f"\nCalculating OPSWAT Security Score ({mode})...")
+
+        score = get_security_score(sdk, force_refresh)
+        print_score_report(score)
+
+        # Write full results to a JSON output file
+        output_file = os.path.join(os.getcwd(), "security_score.json")
+        with open(output_file, "w", encoding="utf-8") as f:
+            json.dump(score, f, indent=2, default=str)
+        print(f"\n  Full results written to: {output_file}")
+
+    except Exception as e:
+        print(f"Received an Exception: {e}")
+    finally:
+        if sdk:
+            try:
+                sdk.teardown()
+            except SDKError:
+                pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- security_score.py: GetSecurityScore (method 111) with per-category breakdown; loads v2mod.dat so the Vulnerabilities category is scored
- collect_device_inventory.py: CollectDeviceInventory (50901), Windows only
- detect_driver_firmware_patches.py: DetectDriverFirmwarePatches (50902), with LoadDriverFirmwareDatabase (50900) and graceful MODEL_NOT_SUPPORTED
- copy_sdk_files.py: stage patch_driver_firmware.dat into sdk/
- README.md: document the three new scripts
- .gitignore: ignore all eval-license secrets except the README