### PR TITLE
Fix three Python sample bugs found during testing

### DIFF
--- a/helloworld/python/discover_products.py
+++ b/helloworld/python/discover_products.py
@@ -25,10 +25,18 @@
 
 import json
 import os
+import sys
 
 from sdk_wrapper import OESISWrapper, SDKError
 from platform_utils import validate_sdk_environment
 from platform_utils import get_lib_filename
+
+# Product names can contain non-ASCII characters. On Windows the console
+# defaults to a legacy code page (cp1252) and printing them raises
+# UnicodeEncodeError ('charmap' codec can't encode ...). Force UTF-8 output
+# where the runtime supports it so discovery never crashes on a product name.
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
 
 # Hardcoded SDK directory relative to this script

--- a/helloworld/python/inline_license.py
+++ b/helloworld/python/inline_license.py
@@ -30,7 +30,7 @@ def initialize_framework():
         print("Could not find pass_key.txt. Make sure the license is in the sdk directory.")
         raise Exception("License pass_key.txt file not found")
 
-        sdk = OESISWrapper(os.path.join(SDK_DIR, get_lib_filename()))
+    sdk = OESISWrapper(os.path.join(SDK_DIR, get_lib_filename()))
     sdk.load()
     sdk.setup(license_path, pass_key_path)
     return sdk

--- a/helloworld/python/os_vulnerability.py
+++ b/helloworld/python/os_vulnerability.py
@@ -23,6 +23,14 @@ import sys
 
 from sdk_wrapper import OESISWrapper, SDKError
 from platform_utils import validate_sdk_environment
+from platform_utils import get_lib_filename
+
+# CVE descriptions can contain non-ASCII characters. On Windows the console
+# defaults to a legacy code page (cp1252) and printing them raises
+# UnicodeEncodeError ('charmap' codec can't encode ...). Force UTF-8 output
+# where the runtime supports it so the report never crashes on CVE text.
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
 # Hardcoded SDK directory relative to this script
 SDK_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sdk")
@@ -41,7 +49,7 @@ def initialize_framework():
         print("Could not find pass_key.txt. Make sure the license is in the sdk directory.")
         raise Exception("License pass_key.txt file not found")
 
-        sdk = OESISWrapper(os.path.join(SDK_DIR, get_lib_filename()))
+    sdk = OESISWrapper(os.path.join(SDK_DIR, get_lib_filename()))
     sdk.load()
     sdk.setup(os.path.join(SDK_DIR, "license.cfg"), pass_key_path)
     return sdk


### PR DESCRIPTION
- inline_license.py: de-indent the sdk = OESISWrapper(...) line that was nested inside the pass_key check, causing 'sdk referenced before assignment'
- os_vulnerability.py: same init de-indent; add the missing get_lib_filename import; force UTF-8 stdout so CVE descriptions don't crash on the Windows cp1252 console ('charmap' codec can't encode)
- discover_products.py: force UTF-8 stdout so non-ASCII product names don't crash the listing on Windows

All three verified end-to-end on Windows.