### PR TITLE
docs: include the Python helloworld samples and fix macOS client-dir …

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It includes everything needed to get started with vulnerability, patch, and comp
 
 | Folder | Description |
 |:-------|:-------------|
-| [**`helloworld/`**](helloworld/README.md) | Sample “Hello World” projects for multiple languages and platforms (Windows C++, Windows C#, Windows Go, Linux C++, macOS C++). Demonstrates basic SDK initialization, scanning, and result retrieval. |
+| [**`helloworld/`**](helloworld/README.md) | Sample “Hello World” projects for multiple languages and platforms (Python, Windows C++, Windows C#, Windows Go, Linux C++, macOS C++). Demonstrates basic SDK initialization, scanning, and result retrieval. |
 | [**`scripts/`**](scripts/README.md) | Python-based data merge and catalog utilities used for building, combining, or analyzing patch and vulnerability datasets. Includes examples for merging analog data, generating associations, and producing JSON outputs. |
 | [**`tools/`**](tools/README.md) | Broader utilities for patch scanning, catalog analysis, and endpoint posture reporting using the SDK. These scripts showcase higher-level posture logic and aggregation. |
 | [**`eval-license/`**](eval-license/README.md) | Directory containing evaluation and licensing artifacts. To use the SDK, place your **license and token files** here. |
@@ -79,6 +79,7 @@ python3 main.py
 ### `helloworld/`
 Contains minimal working examples demonstrating SDK initialization, product scanning, and reporting vulnerability and patch status.  
 Includes examples for:
+- **Python** (cross-platform)
 - **Windows-C++**
 - **Windows-C#**
 - **Windows-Go**

--- a/helloworld/README.md
+++ b/helloworld/README.md
@@ -16,6 +16,7 @@ Each sample shows how to:
 |--------|--------------|
 | **linux-cpp** | C++ HelloWorld sample for Linux |
 | **mac-cpp** | C++ HelloWorld sample for macOS |
+| **python** | Python HelloWorld samples — cross-platform (Windows, macOS, Linux) |
 | **windows-cpp** | C++ HelloWorld sample for Windows |
 | **windows-csharp** | .NET (C#) HelloWorld sample for Windows |
 | **windows-go** | Go (Golang) HelloWorld sample for Windows |
@@ -164,8 +165,23 @@ make
 
 If required, set the library path:
 ```bash
-export DYLD_LIBRARY_PATH=../../OPSWAT-SDK/client/macos/x64:$DYLD_LIBRARY_PATH
+export DYLD_LIBRARY_PATH=../../OPSWAT-SDK/client/mac:$DYLD_LIBRARY_PATH
 ```
+
+---
+
+### 🐍 **Python** (cross-platform)
+
+```bash
+cd python
+python copy_sdk_files.py     # stage SDK binaries + license into ./sdk
+python detect_products.py    # then run any sample
+```
+
+The Python samples run on Windows, macOS, and Linux. `copy_sdk_files.py` stages the
+correct SDK binaries from `OPSWAT-SDK/` and your license files into a local `sdk/`
+directory. See [python/README.md](python/README.md) for the full list of samples and
+usage. Python 3.7+ is required; the samples use only the standard library.
 
 ---
 
@@ -188,7 +204,7 @@ These examples serve as the foundation for OEM partners to build integrations wi
 | **License not found** | Missing files | Copy license files into `eval-license/` |
 | **Illegal characters in path (Windows)** | Trailing backslash in post-build output path | Use `"$(TargetDir)."` in post-build event |
 | **Architecture mismatch** | SDK binaries don’t match build target | Build with the same arch as the SDK (`x64`, `win32`, `arm64`) |
-| **Python module not found** | Missing dependencies | Run `pip3 install -r requirements.txt` |
+| **Python: SDK / license not found** | `copy_sdk_files.py` not run | In `python/`, run `python copy_sdk_files.py` to stage the SDK + license before running a sample |
 
 ---
 

--- a/sdk-downloader/README.md
+++ b/sdk-downloader/README.md
@@ -70,8 +70,9 @@ The script will:
 - Output files to:
   ```
   OPSWAT-SDK/client/linux/<architecture>/
-  OPSWAT-SDK/client/macos/<architecture>/
+  OPSWAT-SDK/client/mac/
   ```
+  (macOS is a flat directory — no architecture subfolder; the dylibs are universal binaries.)
 
 ---
 


### PR DESCRIPTION
…references

- helloworld/README.md: add python to the folder-structure table, add a Python build/run section, fix the Common Issues row (no requirements.txt — run copy_sdk_files.py), and correct the macOS library path (client/mac, not client/macos)
- README.md: add Python to the helloworld language lists (folder table + details)
- sdk-downloader/README.md: macOS output is client/mac/ (flat, universal dylibs), not client/macos/<architecture>/