### PR TITLE
vapm: enable full OS vuln flag, add mapping data-quality warnings, fi…

### DIFF
--- a/tools/python-vapm-scanner/centralized-assessment/map_ca_osdetails.py
+++ b/tools/python-vapm-scanner/centralized-assessment/map_ca_osdetails.py
@@ -342,6 +342,23 @@ def detect_windows_cves(scan, server_dir, os_info, cve_index):
     print(f"  KB base      : {len(kb_base)} builds indexed")
     print(f"  Current build: {current_build}")
 
+    # --- Data-quality warnings (do not alter the mapping; just surface risk) -------------
+    if not kb_to_cves:
+        print(f"  WARNING: no Windows KB->CVE associations found for os_id {os_id}. This OS may "
+              f"not be covered by the catalog (or os_id is wrong) -- OS CVE results may be "
+              f"empty or incomplete.")
+    if not supersede_graph or not kb_base:
+        print(f"  WARNING: no kb_info supersedence/kb_base data for os_id {os_id}. Installed-KB "
+              f"seeding from the build is unavailable, so 'already-fixed' CVEs may not be "
+              f"subtracted (results may over-report).")
+    # A valid Windows build is '<build>.<revision>' (e.g. 26100.6584). If GetOSInfo did not
+    # provide it and we fell back to the version string (e.g. '10.0.26100'), the build-based
+    # installed-patch seeding (compare_builds / kb_base lookups) is unreliable.
+    if not re.match(r"^\d{4,}\.\d+$", current_build):
+        print(f"  WARNING: OS build '{current_build}' is not a <build>.<revision> value "
+              f"(expected e.g. 26100.6584). Build-based installed-patch seeding may be "
+              f"unreliable for this scan.")
+
     # Step 1: installed KBs from scan
     installed_kbs = set()
     for product in scan.get("products", []):

--- a/tools/python-vapm-scanner/centralized-assessment/scan-ca.py
+++ b/tools/python-vapm-scanner/centralized-assessment/scan-ca.py
@@ -9,7 +9,10 @@
 ##    2. Runs the combined mapper (map-ca.py)           -> maps those results to missing
 ##       patches and CVEs via the Analog catalog -> map-ca-result.json.
 ##    3. Produces a final, consolidated report: ca-result.json (derived from
-##       map-ca-result.json).
+##       map-ca-result.json). The OS is reported in its own "os" section and third-party in
+##       "products"; the OS section carries:
+##         patches  -> [{id: KB, name, cves[]}]  the KB(s) remediating the missing OS CVEs
+##         cve_kbs  -> {CVE: [KB]}               direct CVE -> remediating-KB lookup (inverse)
 ##
 ##  Usage:
 ##      python3 copysdk.py      # stage the SDK + license into ./sdk first

--- a/tools/python-vapm-scanner/endpoint-assessment/scan-ea-osdetails.py
+++ b/tools/python-vapm-scanner/endpoint-assessment/scan-ea-osdetails.py
@@ -3,12 +3,24 @@
 ##  VAPM Endpoint Assessment — OS Details / Vulnerabilities (live SDK scan)
 ##  Reference Implementation using the OESIS Framework
 ##
-##  Live, agent-style OS assessment of THIS endpoint. Like helloworld/python/os_vulnerability.py
-##  it loads the Windows OS patch database (wuov2.dat) and vulnerability database
-##  (wiv-lite.dat) and queries the OS component for vulnerabilities. It also gathers OS info
-##  and missing patches so the output matches the centralized mapper's result shape
-##  (map-ca-osdetails-result.json), making the endpoint and centralized assessments
-##  directly comparable.
+##  Live, agent-style OS assessment of THIS endpoint (no server/catalog needed). Workflow:
+##    1. GetOSInfo (1)                      -> OS name / version / os_id / os_type.
+##    2. LoadPatchDatabase (50302, wuov2.dat)        -> Windows OS patch data.
+##       ConsumeOfflineVmodDatabase (50520, wiv-lite.dat) -> Windows OS vulnerability data.
+##       Both load results are captured (version / published date / record counts) into a
+##       'databases' section so the loaded-DB provenance travels with the result.
+##    3. GetProductVulnerability (50505) on the OS signature (default 1103), with
+##       skip_extra_installed_os_patches_checks=true so the engine returns the full OS CVE
+##       set rather than a narrowed subset. Each returned CVE carries the KB that fixes it in
+##       details.resolution; we extract that per-CVE KB and group the result's
+##       missing_patches by the actual remediating KB (the correct OS patch -> CVE mapping).
+##    4. GetLatestInstaller (50300) is recorded separately as 'latest_installer' (the latest
+##       cumulative that brings the OS current); it is NOT used as the per-CVE KB.
+##
+##  Output matches the centralized mapper's shape (map-ca-osdetails-result.json) so the
+##  endpoint and centralized assessments are directly comparable. NOTE: wiv-lite.dat is the
+##  LITE vulnerability DB; its OS CVE coverage is a subset of the full Analog catalog used by
+##  the centralized workflow.
 ##
 ##  Usage:
 ##      python3 copysdk.py                 # stage the SDK + license into ./sdk first
@@ -124,7 +136,11 @@ def get_latest_installer(sdk, signature_id):
 
 def get_os_vulnerabilities(sdk, signature_id):
     # GetProductVulnerability (method 50505) against the loaded wiv-lite.dat.
-    rc, result = sdk.invoke(50505, signature=signature_id)
+    # skip_extra_installed_os_patches_checks=True tells the engine not to suppress CVEs based
+    # on its extra installed-OS-patch heuristics, so the OS vulnerability set is reported in
+    # full (matching the centralized catalog) rather than a narrowed subset.
+    rc, result = sdk.invoke(50505, signature=signature_id,
+                            skip_extra_installed_os_patches_checks=True)
     if rc < 0:
         return []
     return result.get("result", {}).get("cves", []) or []

--- a/tools/python-vapm-scanner/endpoint-assessment/scan-ea.py
+++ b/tools/python-vapm-scanner/endpoint-assessment/scan-ea.py
@@ -8,9 +8,12 @@
 ##      scan-ea-third-party.py  -> detected products + CVEs + CPEs
 ##  then combines them into a single product-centric report at results/ea-result.json.
 ##
-##  The schema matches the centralized scan-ca result (results/ca-result.json): a list of
-##  products, each with signature_id, product_id, name, version, latest_version, and the
-##  vulnerable CVEs and CPEs. All other detail is trimmed.
+##  The schema matches the centralized scan-ca result (results/ca-result.json): the OS in its
+##  own "os" section and "products" for third-party, each with signature_id, product_id, name,
+##  version, latest_version, and the vulnerable CVEs and CPEs. The OS section also carries:
+##      patches  -> [{id: KB, name, cves[]}]  the KB(s) that remediate the missing OS CVEs
+##      cve_kbs  -> {CVE: [KB]}               direct CVE -> remediating-KB lookup (inverse)
+##  All other detail is trimmed.
 ##
 ##  Usage:
 ##      python3 copysdk.py     # stage the SDK + license into ./sdk first


### PR DESCRIPTION
…x docstrings

- scan-ea-osdetails: pass skip_extra_installed_os_patches_checks=true to GetProductVulnerability (50505) so the engine returns the full OS CVE set.
- map_ca_osdetails (detect_windows_cves): add non-invasive warnings (no logic change) for uncovered os_id, missing kb_info supersedence/kb_base, and a malformed build (e.g. the 10.0.26100 fallback) that makes build-based installed-patch seeding unreliable.
- scan-ea-osdetails / scan-ea / scan-ca: correct top docstrings to reflect the current workflow (per-CVE KB mapping, loaded-DB capture, OS section patches[] and cve_kbs).