### PR TITLE
catalog-lookup: add list-supported-apps and catalog-counts

### DIFF
--- a/tools/catalog-lookup/README.md
+++ b/tools/catalog-lookup/README.md
@@ -86,6 +86,28 @@ python find-bulletin.py MS22-0110-5009497
 python find-bulletin.py 5009497
 ```
 
+### `list-supported-apps.py [--source winget|opswat]` — all patchable apps
+Lists every supported third-party application the catalog can patch (`patch_aggregation_v2.json`),
+showing each app's **latest version, signature(s), and source** (`opswat` = OPSWAT‑verified, or
+`winget`), with a **total patch count, a unique‑application count, and a per‑source breakdown**
+(patches + unique apps) at the end. `--source` filters to one source.
+```
+python list-supported-apps.py
+python list-supported-apps.py --source winget
+```
+
+### `catalog-counts.py` — catalog-wide totals
+Prints a census of the whole catalog: applications (unique products + total signatures, **how
+many have vulnerability detection** = a CVE mapping, and patchable apps), **BIOS / Driver /
+Firmware patch counts** (driver_firmware_patch_aggregation.json), unique KBs, unique CVEs
+(cves.json + those referenced by mappings), and total CVE mappings (OS + 3rd-party). The summary
+lists total and unique applications, patchable applications, and driver/firmware/BIOS totals.
+```
+python catalog-counts.py
+```
+> Reads the large `cves.json` (~188 MB) and `vuln_system_associations.json` (~670 MB); the CVE
+> section takes a minute or two and a few GB of RAM.
+
 ## Data sources
 | File | Used for |
 |---|---|
@@ -94,6 +116,8 @@ python find-bulletin.py 5009497
 | `vuln_associations.json` | 3rd‑party CVE ↔ product ↔ CPE (find-cve, find-cpe) |
 | `products.json` | signature/product/vendor names |
 | `patch_associations.json` + `patch_aggregation.json` | signature → patch → latest version/downloads/release notes |
+| `patch_aggregation_v2.json` | supported third-party apps: latest version, signature(s), source (opswat/winget) (list-supported-apps) |
+| `driver_firmware_patch_aggregation.json` | BIOS / driver / firmware patch counts by component and vendor (catalog-counts) |
 | `patch_system_aggregation_v2.json` | OS patch release details (title, date, severity, KB article, download URL+SHA1) and patch/package/bulletin lookups — used by find-kb, find-cve, find-patch, find-package, find-bulletin |
 | `os_info.json` | os_id → OS name |
 

--- a/tools/catalog-lookup/catalog-counts.py
+++ b/tools/catalog-lookup/catalog-counts.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+###############################################################################################
+##  Catalog Lookup — catalog-counts
+##
+##  Print catalog-wide totals from the OPSWAT "Analog" offline catalog:
+##    * Applications      - unique products and total signatures (products.json); how many of
+##                          those products have vulnerability detection (i.e. a CVE mapping in
+##                          vuln_associations.json); and the patchable apps (patch_aggregation_v2).
+##    * Driver/firmware   - BIOS / Driver / Firmware patch counts (driver_firmware_patch_aggregation).
+##    * KBs               - unique KB numbers across every OS section (kb_info.json).
+##    * CVEs              - unique CVEs in cves.json, and unique CVEs referenced by mappings.
+##    * CVE mappings      - OS (vuln_system_associations) + 3rd-party (vuln_associations) rows.
+##
+##  Usage:
+##      python3 catalog-counts.py
+##
+##  Note: cves.json (~188 MB) and vuln_system_associations.json (~670 MB) are large; the CVE
+##  section takes a minute or two and a few GB of RAM to read.
+##
+##  Created by Chris Seiler — OPSWAT OEM Field CTO
+###############################################################################################
+
+import os
+import sys
+from collections import Counter
+
+import _catalog as cat
+
+
+def main():
+    server = cat.require_server_dir()
+
+    print("Catalog counts (OPSWAT Analog)")
+    print("=" * 70)
+
+    # --- Applications (products.json): unique products + total signatures --------------------
+    total_signatures = 0
+    unique_products = set()
+    pj = os.path.join(server, "products.json")
+    if os.path.isfile(pj):
+        for r in cat.read_records(pj):
+            product = r.get("product") or {}
+            pid = product.get("id")
+            if pid is not None:
+                unique_products.add(pid)
+            total_signatures += len(r.get("signatures") or [])
+
+    # --- Patchable applications (patch_aggregation_v2.json, latest) --------------------------
+    pav = os.path.join(server, "patch_aggregation_v2.json")
+    patch_total = 0
+    patch_unique = set()
+    by_source = Counter()
+    if os.path.isfile(pav):
+        for r in cat.read_records(pav):
+            if not r.get("is_latest"):
+                continue
+            patch_total += 1
+            name = (r.get("product") or {}).get("name")
+            if name:
+                patch_unique.add(name)
+            by_source[str(r.get("data_source") or "unknown").lower()] += 1
+
+    # --- Driver / firmware / BIOS patches (driver_firmware_patch_aggregation.json) -----------
+    # This dataset is vendor-keyed ({header, dell, lenovo, ...}); each vendor maps patch-id ->
+    # record with an opswat_component (BIOS / Driver / Firmware / Application / Other).
+    df_total = 0
+    df_by_component = Counter()
+    df_by_vendor = Counter()
+    df_path = os.path.join(server, "driver_firmware_patch_aggregation.json")
+    if os.path.isfile(df_path):
+        dfj = cat.load_json(df_path)
+        for vendor, section in dfj.items():
+            if vendor == "header" or not isinstance(section, dict):
+                continue
+            for _pid, rec in section.items():
+                if not isinstance(rec, dict):
+                    continue
+                df_total += 1
+                df_by_vendor[vendor] += 1
+                df_by_component[str(rec.get("opswat_component") or "unknown")] += 1
+
+    # --- KBs (kb_info.json): unique KB numbers across all OS sections ------------------------
+    unique_kbs = set()
+    ki = cat.load_json(os.path.join(server, "kb_info.json"))
+    for element in ki.get("oesis", []):
+        for key, value in element.items():
+            if key in ("header", "id_os_map") or not isinstance(value, dict):
+                continue
+            for kb in (value.get("kb_tree") or {}):
+                unique_kbs.add(str(kb))
+            for kb in (value.get("kb_cves") or {}):
+                unique_kbs.add(str(kb))
+            for _build, bd in (value.get("kb_base") or {}).items():
+                for patch in (bd or {}).get("kb_articles", []):
+                    k = patch.get("kb_id")
+                    if k and str(k) != "0":
+                        unique_kbs.add(str(k))
+
+    # --- CVE mappings + unique CVEs (large files) --------------------------------------------
+    print("Reading CVE data (large files, please wait)...")
+
+    print("  scanning vuln_system_associations.json (OS mappings)...", flush=True)
+    os_mappings = 0
+    os_cves = set()
+    for r in cat.read_records(os.path.join(server, "vuln_system_associations.json")):
+        cve = r.get("cve")
+        if cve:
+            os_mappings += 1
+            os_cves.add(cve)
+
+    print("  scanning vuln_associations.json (3rd-party mappings)...", flush=True)
+    tp_mappings = 0
+    tp_cves = set()
+    vuln_pids = set()   # products (v4_pid) that have a CVE mapping = have vulnerability detection
+    for r in cat.read_records(os.path.join(server, "vuln_associations.json")):
+        cve = r.get("cve")
+        if cve:
+            tp_mappings += 1
+            tp_cves.add(cve)
+            for pid in (r.get("v4_pids") or []):
+                vuln_pids.add(pid)
+
+    print("  scanning cves.json (CVE database)...", flush=True)
+    cve_db = set()
+    for r in cat.read_records(os.path.join(server, "cves.json")):
+        cve = r.get("cve")
+        if cve:
+            cve_db.add(cve)
+
+    mapped_unique = os_cves | tp_cves
+    apps_with_vuln = len(vuln_pids & unique_products)
+
+    # --- Report ------------------------------------------------------------------------------
+    print("\nApplications (products.json):")
+    print(f"  unique applications (products)     : {len(unique_products)}")
+    print(f"    with vulnerability detection     : {apps_with_vuln}   (have a CVE mapping)")
+    print(f"    detection only (no CVE mapping)  : {len(unique_products) - apps_with_vuln}")
+    print(f"  total application signatures       : {total_signatures}")
+
+    print("Patchable applications (patch_aggregation_v2.json, latest):")
+    print(f"  unique applications                : {len(patch_unique)}")
+    print(f"  total patch entries                : {patch_total}")
+    for src in sorted(by_source):
+        label = "opswat (OPSWAT-verified)" if src == "opswat" else src
+        print(f"    {label:<24}: {by_source[src]}")
+
+    print("Driver / firmware patches (driver_firmware_patch_aggregation.json):")
+    print(f"  BIOS                               : {df_by_component.get('BIOS', 0)}")
+    print(f"  Driver                             : {df_by_component.get('Driver', 0)}")
+    print(f"  Firmware                           : {df_by_component.get('Firmware', 0)}")
+    for comp in sorted(df_by_component):
+        if comp not in ("BIOS", "Driver", "Firmware"):
+            print(f"  {comp:<34} : {df_by_component[comp]}")
+    print(f"  total                              : {df_total}")
+    if df_by_vendor:
+        print(f"  by vendor                          : "
+              + ", ".join(f"{v}={df_by_vendor[v]}" for v in sorted(df_by_vendor)))
+
+    print("KBs (kb_info.json):")
+    print(f"  unique KBs                         : {len(unique_kbs)}")
+
+    print("CVE mappings:")
+    print(f"  OS mappings (vuln_system_associations)   : {os_mappings}")
+    print(f"  3rd-party mappings (vuln_associations)   : {tp_mappings}")
+    print(f"  total CVE mappings                       : {os_mappings + tp_mappings}")
+
+    print("CVEs:")
+    print(f"  unique CVEs in cves.json                 : {len(cve_db)}")
+    print(f"  unique CVEs referenced by mappings       : {len(mapped_unique)}")
+    print(f"    - OS-mapped unique CVEs                 : {len(os_cves)}")
+    print(f"    - 3rd-party-mapped unique CVEs          : {len(tp_cves)}")
+
+    print("\n" + "=" * 70)
+    print("Summary:")
+    print(f"  Applications : {len(unique_products)} unique "
+          f"({apps_with_vuln} with vulnerability detection) / {total_signatures} signatures")
+    print(f"  Patchable    : {len(patch_unique)} unique / {patch_total} patch entries")
+    print(f"  Driver/FW    : {df_total} total "
+          f"(BIOS {df_by_component.get('BIOS', 0)}, Driver {df_by_component.get('Driver', 0)}, "
+          f"Firmware {df_by_component.get('Firmware', 0)})")
+    print(f"  KBs          : {len(unique_kbs)} unique")
+    print(f"  CVEs         : {len(cve_db)} unique")
+    print(f"  CVE mappings : {os_mappings + tp_mappings} total")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/catalog-lookup/list-supported-apps.py
+++ b/tools/catalog-lookup/list-supported-apps.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+###############################################################################################
+##  Catalog Lookup — list-supported-apps
+##
+##  List every supported third-party application the catalog can patch, from
+##  patch_aggregation_v2.json, showing each application's latest version, product signature(s),
+##  and patch source (OPSWAT-verified = "opswat", or "winget"). Prints a total count and a
+##  per-source breakdown at the end.
+##
+##  Only the latest patch per family (is_latest) is listed, so the version shown is the newest
+##  the catalog offers.
+##
+##  Usage:
+##      python3 list-supported-apps.py                 # all sources
+##      python3 list-supported-apps.py --source winget # only winget
+##      python3 list-supported-apps.py --source opswat # only OPSWAT-verified
+##
+##  Created by Chris Seiler — OPSWAT OEM Field CTO
+###############################################################################################
+
+import os
+import sys
+from collections import Counter
+
+import _catalog as cat
+
+
+def main():
+    args = sys.argv[1:]
+    source_filter = None
+    if "--source" in args:
+        i = args.index("--source")
+        if i + 1 < len(args):
+            source_filter = args[i + 1].strip().lower()
+        else:
+            print("Usage: python list-supported-apps.py [--source winget|opswat]")
+            sys.exit(1)
+
+    server = cat.require_server_dir()
+    path = os.path.join(server, "patch_aggregation_v2.json")
+    if not os.path.isfile(path):
+        print(f"ERROR: patch_aggregation_v2.json not found under {server}.")
+        sys.exit(2)
+
+    title = "Catalog supported applications (patch_aggregation_v2.json)"
+    if source_filter:
+        title += f"  [source = {source_filter}]"
+    print(title)
+    print("=" * 78)
+
+    rows = []   # (source, sig_str, version, name)
+    seen = set()
+    for rec in cat.read_records(path):
+        if not rec.get("is_latest"):
+            continue
+        source = str(rec.get("data_source") or "unknown").lower()
+        if source_filter and source != source_filter:
+            continue
+        product = rec.get("product") or {}
+        name = product.get("name") or "(unknown)"
+        version = rec.get("version") or "?"
+        sigs = product.get("v4_signatures") or []
+        sig_str = ", ".join(str(s) for s in sigs) or "(none)"
+
+        key = (source, sig_str, version, name)
+        if key in seen:
+            continue
+        seen.add(key)
+        rows.append((source, sig_str, version, name))
+
+    rows.sort(key=lambda r: (r[0], r[3].lower(), r[1]))
+
+    print(f"  {'SOURCE':<9} {'SIGNATURE(S)':<16} {'LATEST VERSION':<22} APPLICATION")
+    print("  " + "-" * 74)
+    for source, sig_str, version, name in rows:
+        print(f"  {source:<9} {sig_str[:16]:<16} {str(version)[:22]:<22} {name}")
+
+    by_source = Counter(r[0] for r in rows)
+    unique_all = {r[3] for r in rows}
+    print("\n" + "=" * 78)
+    print(f"Total: {len(rows)} supported application patch(es) across "
+          f"{len(unique_all)} unique application(s)")
+    for src in sorted(by_source):
+        label = "OPSWAT-verified (opswat)" if src == "opswat" else src
+        unique_src = len({r[3] for r in rows if r[0] == src})
+        print(f"  {label:<26}: {by_source[src]} patch(es), {unique_src} unique app(s)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
list-supported-apps.py: list every patchable third-party application from patch_aggregation_v2.json with its latest version, signature(s), and source (opswat / winget); prints total patch count, unique-application count, and a per-source breakdown. --source filters to one source.

catalog-counts.py: catalog-wide census - applications (unique products + total signatures, how many have vulnerability detection = a CVE mapping, and patchable apps), BIOS/Driver/Firmware patch counts (driver_firmware_patch_aggregation.json), unique KBs, unique CVEs (cves.json + those referenced by mappings), and total CVE mappings (OS + 3rd-party), with a summary block.