### PR TITLE
python-vapm-scanner: add helper scripts and update centralized-assess…

### DIFF
--- a/tools/python-vapm-scanner/centralized-assessment/map_ca_osdetails.py
+++ b/tools/python-vapm-scanner/centralized-assessment/map_ca_osdetails.py
@@ -449,17 +449,7 @@ def detect_windows_cves(scan, server_dir, os_info, cve_index):
         for patch in product.get("missing_patches", []):
             scan_reported_missing_kbs |= kb_candidates(patch)
 
-    # Step 5b: forward supersedence. The agent's GetMissingPatches (1013) can report a stale
-    # "latest offered" KB; promote the missing set to the newer cumulative KBs that supersede
-    # it so the latest cumulative's CVEs (e.g. current-month fixes) are not dropped. This
-    # mirrors the endpoint engine's appendMissingCumulKB and keeps the two workflows aligned.
-    superseding_kbs = get_superseding_cumulative_kbs(
-        scan_reported_missing_kbs, supersede_graph, cumulative_kbs)
-    if superseding_kbs:
-        print(f"  Forward supersedence: promoted missing set with "
-              f"{len(superseding_kbs)} newer cumulative KB(s): {sorted(superseding_kbs)}")
-
-    # Step 5c: build-history recovery (mirrors the endpoint engine's getMissingKBFromBuildHistory).
+    # Step 5b: build-history recovery (mirrors the endpoint engine's getMissingKBFromBuildHistory).
     # GetMissingPatches only offers the latest cumulative and forward supersedence walks the
     # chain up one hop, so the intervening months' cumulatives are still missing from the set.
     # Pull every KB whose build is newer than the running build: those fix CVEs not yet applied.
@@ -467,6 +457,17 @@ def detect_windows_cves(scan, server_dir, os_info, cve_index):
     if later_build_kbs:
         print(f"  Build-history recovery: added {len(later_build_kbs)} KB(s) from builds newer "
               f"than {current_build}")
+
+    # Step 5c: forward supersedence. Promote the missing set to the newer cumulative KBs that
+    # supersede any known-missing KB so the latest cumulative's CVEs (e.g. current-month fixes)
+    # are not dropped. This mirrors the endpoint engine's appendMissingCumulKB which runs on
+    # the full missingKBList (scan-reported + build-history) before calcAffectedCvesList.
+    superseding_kbs = get_superseding_cumulative_kbs(
+        scan_reported_missing_kbs | later_build_kbs, supersede_graph, cumulative_kbs)
+    if superseding_kbs:
+        print(f"  Forward supersedence: promoted missing set with "
+              f"{len(superseding_kbs)} newer cumulative KB(s): {sorted(superseding_kbs)}")
+
     missing_kbs_input = scan_reported_missing_kbs | superseding_kbs | later_build_kbs
 
     # ------------------------------------------------------------------

--- a/tools/python-vapm-scanner/helper/copysdk.py
+++ b/tools/python-vapm-scanner/helper/copysdk.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+###############################################################################################
+##  Copy SDK Files
+##  Stages the correct OPSWAT SDK client binaries, data files, and license files into the
+##  local sdk/ directory for this VAPM scanner sample. Mirrors the helloworld/python approach.
+##
+##  Usage:
+##      python3 copysdk.py
+##
+##  Walks up from this script to find the 'sdkroot' marker (repo root), then copies:
+##      OPSWAT-SDK/client/<os>/[<arch>/]   -->  ./sdk
+##      eval-license/                      -->  ./sdk
+##
+##  Run the SDK downloader (sdk-downloader) first so OPSWAT-SDK/ exists.
+##
+##  Created by Chris Seiler
+##  OPSWAT OEM Solutions Architect
+###############################################################################################
+
+import os
+import platform
+import shutil
+import sys
+
+
+def get_os_dir():
+    p = sys.platform
+    if p == "win32":
+        return "windows"
+    elif p == "darwin":
+        return "mac"
+    elif p.startswith("linux"):
+        return "linux"
+    raise RuntimeError(f"Unsupported platform: {p}")
+
+
+def get_arch_dir():
+    # Maps the current CPU to the OPSWAT-SDK client subdirectory name.
+    # macOS is flat (universal binaries) — no architecture subfolder.
+    machine = platform.machine().lower()
+    os_dir = get_os_dir()
+    if machine in ("x86_64", "amd64"):
+        return None if os_dir == "mac" else "x64"
+    elif machine in ("i386", "i686", "x86"):
+        return None if os_dir == "mac" else ("win32" if os_dir == "windows" else "x86")
+    elif machine in ("arm64", "aarch64"):
+        return None if os_dir == "mac" else "arm64"
+    raise RuntimeError(f"Unsupported architecture: {machine}")
+
+
+def find_repo_root(start_path):
+    # Walk up until a directory containing the 'sdkroot' marker file is found.
+    current = os.path.abspath(start_path)
+    while True:
+        if os.path.isfile(os.path.join(current, "sdkroot")):
+            return current
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
+    raise FileNotFoundError(
+        "Could not find the 'sdkroot' marker file in any parent directory."
+    )
+
+
+def copy_files(src_dir, dst_dir, label):
+    if not os.path.isdir(src_dir):
+        raise FileNotFoundError(f"Source directory not found: {src_dir}")
+    os.makedirs(dst_dir, exist_ok=True)
+    print(f"Copying {label}:\n  {src_dir}\n  -> {dst_dir}")
+    for filename in os.listdir(src_dir):
+        src = os.path.join(src_dir, filename)
+        dst = os.path.join(dst_dir, filename)
+        if os.path.isfile(src):
+            shutil.copy2(src, dst)
+            print(f"  Copied {filename}")
+
+
+def main():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    sdk_dst = os.path.join(script_dir, "sdk")
+
+    try:
+        repo_root = find_repo_root(script_dir)
+    except FileNotFoundError as e:
+        print(f"ERROR: {e}")
+        sys.exit(1)
+
+    print(f"Repo root: {repo_root}")
+
+    os_dir = get_os_dir()
+    arch_dir = get_arch_dir()
+    if arch_dir:
+        sdk_src = os.path.join(repo_root, "OPSWAT-SDK", "client", os_dir, arch_dir)
+    else:
+        sdk_src = os.path.join(repo_root, "OPSWAT-SDK", "client", os_dir)
+
+    license_src = os.path.join(repo_root, "eval-license")
+
+    # The SDK downloader must have produced the client binaries.
+    if not os.path.isdir(sdk_src):
+        print(f"ERROR: SDK client directory not found: {sdk_src}")
+        print("       Run the SDK downloader first to populate OPSWAT-SDK/:")
+        print("         Windows:     sdk-downloader\\windows-csharp\\bin\\SDKDownloader.exe")
+        print("         Linux/macOS: python3 sdk-downloader/script/src/main.py")
+        sys.exit(1)
+
+    # Validate the license files exist before copying anything.
+    for required in ("license.cfg", "pass_key.txt"):
+        if not os.path.isfile(os.path.join(license_src, required)):
+            print(f"ERROR: {required} not found in {license_src}")
+            sys.exit(1)
+
+    # Clean the sdk directory first so stale files from a previous run (or a different
+    # architecture / SDK version) don't linger.
+    if os.path.isdir(sdk_dst):
+        print(f"Cleaning existing SDK directory: {sdk_dst}")
+        shutil.rmtree(sdk_dst)
+
+    try:
+        copy_files(sdk_src, sdk_dst, "SDK binaries")
+        copy_files(license_src, sdk_dst, "license files")
+        print(f"\nDone. SDK ready at: {sdk_dst}")
+    except FileNotFoundError as e:
+        print(f"ERROR: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/python-vapm-scanner/helper/map_cve_to_kb.py
+++ b/tools/python-vapm-scanner/helper/map_cve_to_kb.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+###############################################################################################
+##  VAPM Helper — Endpoint System-Vulnerability APIs & CVE<->KB mapping (live SDK demo)
+##  Reference Implementation using the OESIS Framework
+##
+##  Demonstrates the OESIS *system-level* vulnerability methods on the endpoint and what they
+##  do / don't provide for OS CVE<->KB mapping. These are distinct from GetProductVulnerability
+##  (50505, per-product):
+##
+##    GetSystemVulnerabilities          (50509) -> aggregate vulnerabilities present on the
+##                                                 system (CVEs + affected products + fixes).
+##    GetSystemVulnsByInstalledPatches  (50508) -> intended KB-list -> CVE mapper.
+##    GetSupportedDetectableVulns       (50507) -> what the loaded source can detect.
+##
+##  KEY INITIALIZATION NOTE (this is what causes "not initialized" errors):
+##    The system methods query the OFFLINE VMOD source, which must be loaded with v2mod.dat
+##    via ConsumeOfflineVmodDatabase (50520). Loading wiv-lite.dat does NOT initialize this
+##    source, so the methods return:
+##        -1019 WA_VMOD_ERROR_OFFLINEVMOD_NOT_INITIALIZED   (50507/50508)
+##        -16   WAAPI_ERROR_DATABASE_NOT_INITIALIZED         (50509)
+##    Loading v2mod.dat fixes that and 50509/50507 succeed.
+##
+##  WHAT WE LEARN (verified on this SDK build 4.3.x + offline data):
+##    * 50509 succeeds with v2mod but returns THIRD-PARTY product CVEs (Chrome, Python, etc.)
+##      with ZERO KB associations and no OS/Windows-Update-Agent (sig 1103) entry. v2mod is
+##      the third-party vuln source; it does not carry OS KB<->CVE data.
+##    * 50508 (the KB-list -> CVE mapper) returns -12 NOT_IMPLEMENTED in this engine build.
+##    * OS CVE<->KB association therefore is NOT available from the endpoint with this data;
+##      it requires a KB-bearing WIV source (wiv-lite has number_of_kbs = 0). That mapping is
+##      what the CENTRALIZED workflow provides via the Analog catalog (kb_info / vuln_system_
+##      associations).
+##
+##  Usage:
+##      python3 copysdk.py            # stage the SDK + license into ./sdk first
+##      python3 map_cve_to_kb.py [signature_id]   # default OS signature 1103
+##
+##  Created by Chris Seiler
+##  OPSWAT OEM Solutions Architect
+###############################################################################################
+
+import json
+import os
+import sys
+
+from sdk_wrapper import OESISWrapper, SDKError
+from platform_utils import validate_sdk_environment, get_lib_filename
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+SDK_DIR    = os.path.join(SCRIPT_DIR, "sdk")
+
+WUO_DAT      = os.path.join(SDK_DIR, "wuov2.dat")     # Windows OS patch database (LoadPatchDatabase)
+V2MOD_DAT    = os.path.join(SDK_DIR, "v2mod.dat")     # offline vmod (vulnerability) source
+WIV_LITE_DAT = os.path.join(SDK_DIR, "wiv-lite.dat")  # lite Windows vuln DB (no KB source)
+
+DEFAULT_OS_SIGNATURE = 1103
+OUTPUT_FILE = os.path.join(SCRIPT_DIR, "map-cve-to-kb-result.json")
+
+M_GET_OS_INFO                    = 1
+M_GET_MISSING_PATCHES            = 1013
+M_GET_INSTALLED_PATCHES          = 1023
+M_LOAD_PATCH_DATABASE            = 50302
+M_GET_SUPPORTED_DETECTABLE_VULNS = 50507
+M_GET_SYSTEM_VULNS_BY_PATCHES    = 50508
+M_GET_SYSTEM_VULNERABILITIES     = 50509
+M_CONSUME_OFFLINE_VMOD_DATABASE  = 50520
+
+
+def initialize_framework():
+    pass_key_path = os.path.join(SDK_DIR, "pass_key.txt")
+    if not os.path.isfile(pass_key_path):
+        raise Exception("License pass_key.txt not found in the sdk directory (run copysdk.py).")
+    sdk = OESISWrapper(os.path.join(SDK_DIR, get_lib_filename()))
+    sdk.load()
+    sdk.setup(os.path.join(SDK_DIR, "license.cfg"), pass_key_path)
+    return sdk
+
+
+def invoke(sdk, method, **kwargs):
+    rc, result = sdk.invoke(method, **kwargs)
+    return rc, (result or {})
+
+
+def err_define(result):
+    e = (result or {}).get("error", {})
+    return f"{e.get('define', '')} {e.get('description', '')}".strip()
+
+
+def load_db(sdk, method, dat_file, label):
+    if not os.path.isfile(dat_file):
+        print(f"  {label}: {os.path.basename(dat_file)} not found -- skipping")
+        return {}, -1
+    rc, result = invoke(sdk, method, dat_input_source_file=dat_file)
+    res = result.get("result", {}) if rc >= 0 else {}
+    print(f"  {label}: {os.path.basename(dat_file)}  rc={rc}  v{res.get('version')}  "
+          f"details={res.get('details')}")
+    return res, rc
+
+
+def kb_list_from_patches(patches):
+    import re
+    kbs = set()
+    for p in patches or []:
+        for field in ("security_update_id", "kb_id", "id"):
+            v = p.get(field)
+            if v and str(v).upper().replace("KB", "").strip().isdigit():
+                kbs.add(str(v).upper().replace("KB", "").strip())
+        for m in re.findall(r"KB(\d+)", p.get("title", "") or "", flags=re.IGNORECASE):
+            kbs.add(m)
+    return sorted(kbs)
+
+
+def summarize_system_vulns(result):
+    """Summarize a GetSystemVulnerabilities result: CVE count, how many carry KB
+    associations, whether the OS (sig 1103) appears, and the per-product breakdown."""
+    cves = result.get("result", {}).get("cves", []) or []
+    with_kb, os_present, products = 0, False, {}
+    cve_kb_pairs = []
+    for c in cves:
+        kbs = c.get("kbs") or c.get("kb") or c.get("kb_articles") or []
+        if isinstance(kbs, (str, int)):
+            kbs = [str(kbs)]
+        kbs = [str(k.get("kb_id") if isinstance(k, dict) else k) for k in kbs]
+        if kbs:
+            with_kb += 1
+        cve_kb_pairs.append({"cve": c.get("cve"), "kbs": kbs})
+        for ap in c.get("affected_products", []) or []:
+            if ap.get("signature") == DEFAULT_OS_SIGNATURE:
+                os_present = True
+            name = (ap.get("product") or {}).get("name")
+            products[name] = products.get(name, 0) + 1
+    return {
+        "total_cves":          len(cves),
+        "cves_with_kb":        with_kb,
+        "os_signature_present": os_present,
+        "by_product":          products,
+        "cve_kb_pairs":        cve_kb_pairs,
+    }
+
+
+def main(signature_id=DEFAULT_OS_SIGNATURE):
+    if len(sys.argv) > 1:
+        try:
+            signature_id = int(sys.argv[1])
+        except ValueError:
+            print(f"Invalid signature ID '{sys.argv[1]}'")
+            return
+    if not validate_sdk_environment(SDK_DIR):
+        return
+
+    sdk = None
+    try:
+        sdk = initialize_framework()
+        print("\nVAPM Helper — Endpoint system-vulnerability APIs & CVE<->KB mapping (live)")
+        print("=" * 74)
+
+        os_info = invoke(sdk, M_GET_OS_INFO)[1].get("result", {})
+        os_id = os_info.get("os_id")
+        print(f"  OS: {os_info.get('name','Unknown')} ({os_info.get('version','')}), os_id={os_id}")
+
+        # The system-vuln methods query the OFFLINE VMOD source -> must load v2mod.dat (50520).
+        # (Loading wiv-lite.dat here is what produced the 'not initialized' errors.)
+        print("\nLoading databases (offline vmod source = v2mod.dat)...")
+        load_db(sdk, M_LOAD_PATCH_DATABASE, WUO_DAT, "patch DB   (50302)")
+        vuln_db, vrc = load_db(sdk, M_CONSUME_OFFLINE_VMOD_DATABASE, V2MOD_DAT, "vuln source(50520)")
+        wiv, _ = load_db(sdk, M_CONSUME_OFFLINE_VMOD_DATABASE, WIV_LITE_DAT, "wiv-lite   (50520)")
+        print(f"\n  Note: wiv-lite.dat number_of_kbs = {(wiv.get('details') or {}).get('number_of_kbs')} "
+              f"(no KB source -> cannot map OS CVEs to KBs)")
+
+        installed = invoke(sdk, M_GET_INSTALLED_PATCHES, signature=signature_id, timeout=0,
+                           retry_internet_services=True, mode=0)[1].get("result", {}).get("patches", [])
+        missing = invoke(sdk, M_GET_MISSING_PATCHES, signature=signature_id, timeout=0,
+                         retry_internet_services=True, mode=0)[1].get("result", {}).get("patches", [])
+        installed_kbs = kb_list_from_patches(installed)
+        missing_kbs = kb_list_from_patches(missing)
+        print(f"\n  Installed KBs ({len(installed_kbs)}): {installed_kbs}")
+        print(f"  Missing KBs   ({len(missing_kbs)}): {missing_kbs}")
+
+        results = {}
+
+        # 50509 GetSystemVulnerabilities
+        print("\n[50509] GetSystemVulnerabilities ...")
+        rc, r = invoke(sdk, M_GET_SYSTEM_VULNERABILITIES, os_id=os_id, signature=signature_id,
+                       installed_patches=installed_kbs, missing_patches=missing_kbs)
+        if rc < 0:
+            print(f"  rc={rc}  {err_define(r)}")
+            results["get_system_vulnerabilities"] = {"rc": rc, "error": err_define(r)}
+        else:
+            summ = summarize_system_vulns(r)
+            results["get_system_vulnerabilities"] = {"rc": rc, **{k: v for k, v in summ.items()
+                                                                  if k != "cve_kb_pairs"}}
+            print(f"  rc=0  CVEs={summ['total_cves']}  with_KB_association={summ['cves_with_kb']}  "
+                  f"OS(sig 1103) present={summ['os_signature_present']}")
+            print("  by product:")
+            for n, ct in sorted(summ["by_product"].items(), key=lambda kv: -kv[1]):
+                print(f"     {n}: {ct}")
+
+        # 50508 GetSystemVulnsByInstalledPatches (the KB-list -> CVE mapper)
+        print("\n[50508] GetSystemVulnsByInstalledPatches ...")
+        rc, r = invoke(sdk, M_GET_SYSTEM_VULNS_BY_PATCHES, os_id=os_id,
+                       installed_patches=installed_kbs, missing_patches=missing_kbs)
+        results["get_system_vulns_by_installed_patches"] = {"rc": rc, "error": err_define(r) if rc < 0 else ""}
+        print(f"  rc={rc}  {err_define(r) if rc < 0 else 'OK'}")
+
+        # 50507 GetSupportedDetectableVulns
+        print("\n[50507] GetSupportedDetectableVulns ...")
+        rc, r = invoke(sdk, M_GET_SUPPORTED_DETECTABLE_VULNS)
+        results["get_supported_detectable_vulns"] = {"rc": rc, "error": err_define(r) if rc < 0 else ""}
+        print(f"  rc={rc}  {err_define(r) if rc < 0 else 'OK'}")
+
+        output = {
+            "os_info": {"name": os_info.get("name"), "version": os_info.get("version"), "os_id": os_id},
+            "wiv_lite_number_of_kbs": (wiv.get("details") or {}).get("number_of_kbs"),
+            "installed_kbs": installed_kbs,
+            "missing_kbs": missing_kbs,
+            "methods": results,
+        }
+        with open(OUTPUT_FILE, "w", encoding="utf-8") as f:
+            json.dump(output, f, indent=2, default=str)
+
+        print("\n" + "=" * 74)
+        print("  CONCLUSION")
+        print("=" * 74)
+        print("  * 50509 GetSystemVulnerabilities works (with v2mod) but returns THIRD-PARTY")
+        print("    product CVEs, with 0 KB associations and no OS (sig 1103) entry -- v2mod is")
+        print("    the third-party vuln source and carries no OS KB<->CVE data.")
+        print("  * 50508 (KB-list -> CVE mapper) is NOT IMPLEMENTED in this engine build (-12).")
+        print("  * wiv-lite.dat has number_of_kbs = 0, so there is no KB-bearing OS vuln source")
+        print("    on the endpoint. OS CVE<->KB association requires a full WIV source (not")
+        print("    shipped here) -- which is exactly what the CENTRALIZED catalog workflow does.")
+        print(f"\n  Results written to: {OUTPUT_FILE}")
+
+    except Exception as e:
+        print(f"Received an Exception: {e}")
+    finally:
+        if sdk:
+            try:
+                sdk.teardown()
+            except SDKError:
+                pass
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/python-vapm-scanner/helper/platform_utils.py
+++ b/tools/python-vapm-scanner/helper/platform_utils.py
@@ -1,0 +1,310 @@
+import logging
+import os
+import platform
+import shutil
+import socket
+import sys
+
+logger = logging.getLogger("endpoint_vuln_scanner")
+
+# OESIS OS type constants — these integer values match the OESIS SDK API contract
+OS_TYPE_WINDOWS = 1
+OS_TYPE_LINUX   = 2
+OS_TYPE_MACOS   = 4
+
+
+# ---------------------------------------------------------------------------
+# Platform detection
+# ---------------------------------------------------------------------------
+
+def get_os_type():
+    """Return the OESIS OS type constant for the current platform.
+
+    Raises RuntimeError for unsupported platforms.
+    """
+    p = sys.platform
+    if p == "win32":
+        return OS_TYPE_WINDOWS
+    elif p == "darwin":
+        return OS_TYPE_MACOS
+    elif p.startswith("linux"):
+        return OS_TYPE_LINUX
+    else:
+        raise RuntimeError(f"Unsupported platform: {p}")
+
+
+def get_lib_filename():
+    """Return the libwaapi filename for the current OS."""
+    os_type = get_os_type()
+
+    logger.info(
+        f"Finding files for  {os_type}"
+    )
+
+    if os_type == OS_TYPE_WINDOWS:
+        return "libwaapi.dll"
+    elif os_type == OS_TYPE_MACOS:
+        return "libwaapi.dylib"
+    elif os_type == OS_TYPE_LINUX:
+        return "libwaapi.so"
+    else:
+        raise RuntimeError(f"Cannot determine library filename for platform: {sys.platform}")
+
+
+def get_architecture():
+    """Return a normalised architecture string for the current CPU.
+
+    Return values map directly to the subdirectory names used in the
+    OPSWAT-SDK client directory structure.
+    """
+    machine = platform.machine().lower()
+    if machine in ("x86_64", "amd64"):
+        return "64-bit"
+    elif machine in ("i386", "i686", "x86"):
+        return "32-bit"
+    elif machine in ("arm64", "aarch64"):
+        return "arm64"
+    return machine
+
+
+def get_hostname():
+    """Return the hostname of the current machine."""
+    return socket.gethostname()
+
+
+# ---------------------------------------------------------------------------
+# DAT file paths
+# ---------------------------------------------------------------------------
+
+def get_dat_files(dat_path):
+    """Return a dict of DAT file paths for the current platform.
+
+    Each key is a logical name used by the scanner; each value is the
+    absolute path to that DAT file under dat_path. Files are platform-specific
+    because OPSWAT ships separate DATs for Windows, macOS, and Linux.
+    """
+    os_type = get_os_type()
+
+    # v2mod.dat is cross-platform — covers 3rd-party application vulnerabilities
+    files = {
+        "v2mod": os.path.join(dat_path, "v2mod.dat"),
+    }
+
+    if os_type == OS_TYPE_WINDOWS:
+        files["patch"]       = os.path.join(dat_path, "patch.dat")
+        files["ap_checksum"] = os.path.join(dat_path, "ap_checksum.dat")
+        files["wuov2"]       = os.path.join(dat_path, "wuov2.dat")
+        files["wiv_lite"]    = os.path.join(dat_path, "wiv-lite.dat")
+    elif os_type == OS_TYPE_MACOS:
+        files["patch"]       = os.path.join(dat_path, "patch_mac.dat")
+        files["ap_checksum"] = os.path.join(dat_path, "ap_checksum_mac.dat")
+        files["mav"]         = os.path.join(dat_path, "mav.dat")
+    elif os_type == OS_TYPE_LINUX:
+        files["patch"]       = os.path.join(dat_path, "patch_linux.dat")
+        files["ap_checksum"] = os.path.join(dat_path, "ap_checksum.dat")
+        files["liv"]         = os.path.join(dat_path, "liv.dat")
+
+    return files
+
+
+# ---------------------------------------------------------------------------
+# SDK repo discovery
+# ---------------------------------------------------------------------------
+
+def find_sdk_in_repo(script_path):
+    """Search up to 2 directories above script_path for the OPSWAT-SDK client directory.
+
+    Expected repo structure:
+        <repo_root>/
+          OPSWAT-SDK/
+            client/
+              linux/
+                arm64/   x64/   x86/
+              mac/                       <-- no arch subfolder on macOS
+              windows/
+                arm64/   win32/   x64/
+
+    If OPSWAT-SDK is not found at either level the user is told to run
+    SDK_Downloader. If the directory exists but the client folder is missing,
+    the user is told to run SDK_Downloader to populate it.
+
+    Returns the path to the correct OS/architecture client directory, or None.
+    """
+    # Maps OS type -> architecture string -> SDK subdirectory name
+    ARCH_MAP = {
+        OS_TYPE_LINUX:   {"64-bit": "x64", "32-bit": "x86",   "arm64": "arm64"},
+        OS_TYPE_WINDOWS: {"64-bit": "x64", "32-bit": "win32", "arm64": "arm64"},
+        OS_TYPE_MACOS:   {},  # macOS client directory is flat — no arch subfolder
+    }
+
+    # Maps OS type -> client OS subdirectory name
+    OS_DIR_MAP = {
+        OS_TYPE_LINUX:   "linux",
+        OS_TYPE_WINDOWS: "windows",
+        OS_TYPE_MACOS:   "mac",
+    }
+
+    os_type = get_os_type()
+    arch    = get_architecture()
+
+    search_root = os.path.abspath(script_path)
+    for _ in range(2):
+        search_root   = os.path.dirname(search_root)
+        opswat_sdk_dir = os.path.join(search_root, "OPSWAT-SDK")
+
+        # OPSWAT-SDK not present at this level — keep walking up
+        if not os.path.isdir(opswat_sdk_dir):
+            continue
+
+        # OPSWAT-SDK found but client directory is absent — incomplete download
+        candidate_client = os.path.join(opswat_sdk_dir, "client")
+        if not os.path.isdir(candidate_client):
+            logger.error(
+                f"Found OPSWAT-SDK at {opswat_sdk_dir} but the 'client' "
+                f"directory is missing. Please run SDK_Downloader to populate it."
+            )
+            return None
+
+        # client found — check for the OS subdirectory
+        os_dir = os.path.join(candidate_client, OS_DIR_MAP[os_type])
+        if not os.path.isdir(os_dir):
+            logger.warning(
+                f"Found OPSWAT-SDK/client but no OS directory for "
+                f"'{OS_DIR_MAP[os_type]}'. Please run SDK_Downloader."
+            )
+            return None
+
+        # macOS client directory is flat — return it directly
+        if os_type == OS_TYPE_MACOS:
+            return os_dir
+
+        # Linux and Windows have an architecture subdirectory
+        arch_subdir = ARCH_MAP[os_type].get(arch)
+        if not arch_subdir:
+            logger.warning(f"No SDK architecture mapping for: {arch}")
+            return None
+
+        arch_dir = os.path.join(os_dir, arch_subdir)
+        if os.path.isdir(arch_dir):
+            return arch_dir
+
+        logger.warning(
+            f"Found OPSWAT-SDK/client/{OS_DIR_MAP[os_type]} "
+            f"but no architecture directory: {arch_subdir}"
+        )
+        return None
+
+    # Exhausted both levels without finding OPSWAT-SDK at all
+    logger.error(
+        f"OPSWAT-SDK directory not found in the 2 directories above "
+        f"{script_path}. Please run SDK_Downloader to set up the SDK "
+        f"before running this tool."
+    )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Environment validation
+# ---------------------------------------------------------------------------
+
+def validate_sdk_environment(sdk_dir):
+    """Check that the sdk directory is ready to use before running any sample.
+
+    Verifies:
+      1. The sdk directory exists
+      2. The correct libwaapi library for this platform is present
+         (libwaapi.dll on Windows, libwaapi.dylib on macOS, libwaapi.so on Linux)
+      3. license.cfg exists in the sdk directory
+      4. pass_key.txt exists in the sdk directory
+
+    Prints a clear message for each missing item and returns False if anything
+    is wrong, so callers can exit immediately with a prompt to run copy_sdk_files.py.
+
+    Returns True if all checks pass, False otherwise.
+    """
+    lib_name = get_lib_filename()
+    ok = True
+
+    if not os.path.isdir(sdk_dir):
+        print(f"  ERROR: sdk directory not found: {sdk_dir}")
+        return False
+
+    if not os.path.isfile(os.path.join(sdk_dir, lib_name)):
+        print(f"  ERROR: SDK library not found: {lib_name} (expected in {sdk_dir})")
+        ok = False
+
+    if not os.path.isfile(os.path.join(sdk_dir, "license.cfg")):
+        print(f"  ERROR: license.cfg not found in {sdk_dir}")
+        ok = False
+
+    if not os.path.isfile(os.path.join(sdk_dir, "pass_key.txt")):
+        print(f"  ERROR: pass_key.txt not found in {sdk_dir}")
+        ok = False
+
+    if not ok:
+        print()
+        print("Run copy_sdk_files.py to prepare the environment before running this sample:")
+        print("    python copy_sdk_files.py")
+
+    return ok
+
+
+# ---------------------------------------------------------------------------
+# SDK library resolution
+# ---------------------------------------------------------------------------
+
+def resolve_sdk_lib_path(sdk_path):
+    """Find the libwaapi library file for the current OS and architecture.
+
+    Search order:
+      1. Directly in sdk_path (e.g. sdk/libwaapi.so)
+      2. In an architecture subdirectory under sdk_path (e.g. sdk/x64/libwaapi.so)
+      3. In the OPSWAT-SDK repo client directory up to 2 levels above sdk_path.
+         If found there, all files in that directory are copied into sdk_path
+         so subsequent runs find them locally without needing the repo.
+
+    Raises FileNotFoundError if the library cannot be found anywhere and
+    the OPSWAT-SDK repo structure is also absent.
+    """
+    lib_name = get_lib_filename()
+
+    # 1. Direct path
+    direct = os.path.join(sdk_path, lib_name)
+    if os.path.isfile(direct):
+        return direct
+
+    # 2. Architecture subdirectory
+    arch = get_architecture()
+    arch_map = {
+        "64-bit": "x64",
+        "32-bit": "win32" if get_os_type() == OS_TYPE_WINDOWS else "x86",
+        "arm64":  "arm64",
+    }
+    subdir   = arch_map.get(arch, "x64")
+    in_subdir = os.path.join(sdk_path, subdir, lib_name)
+    if os.path.isfile(in_subdir):
+        return in_subdir
+
+    # 3. Repo fallback — search OPSWAT-SDK/client/<os>/<arch> up to 2 levels up
+    repo_arch_dir = find_sdk_in_repo(sdk_path)
+    if repo_arch_dir:
+        repo_lib = os.path.join(repo_arch_dir, lib_name)
+        if os.path.isfile(repo_lib):
+            os.makedirs(sdk_path, exist_ok=True)
+            logger.info(
+                f"SDK not found in {sdk_path} — copying from repo: {repo_arch_dir}"
+            )
+            for filename in os.listdir(repo_arch_dir):
+                src = os.path.join(repo_arch_dir, filename)
+                dst = os.path.join(sdk_path, filename)
+                if os.path.isfile(src):
+                    shutil.copy2(src, dst)
+                    logger.debug(f"  Copied {filename}")
+            logger.info(f"SDK files copied to {sdk_path}")
+            return os.path.join(sdk_path, lib_name)
+
+    raise FileNotFoundError(
+        f"Could not find {lib_name} in '{sdk_path}', '{sdk_path}/{subdir}', "
+        f"or in the OPSWAT-SDK repo client directory 2 levels up. "
+        f"Please run SDK_Downloader to set up the SDK."
+    )

--- a/tools/python-vapm-scanner/helper/sdk_wrapper.py
+++ b/tools/python-vapm-scanner/helper/sdk_wrapper.py
@@ -1,0 +1,204 @@
+﻿import ctypes
+import json
+import logging
+import os
+import sys
+
+from platform_utils import get_os_type, OS_TYPE_WINDOWS, OS_TYPE_MACOS, OS_TYPE_LINUX
+
+logger = logging.getLogger("endpoint_vuln_scanner")
+
+
+class SDKError(Exception):
+    """Raised when an SDK call returns a negative error code."""
+    def __init__(self, func_name, rc, detail=None):
+        self.func_name = func_name
+        self.rc = rc
+        self.detail = detail
+        msg = f"{func_name} failed with code {rc}"
+        if detail:
+            msg += f": {detail}"
+        super().__init__(msg)
+
+
+class OESISWrapper:
+    """Python ctypes wrapper around the OESIS libwaapi native library."""
+
+    def __init__(self, lib_path):
+        self.lib_path = lib_path
+        self._lib = None
+        self._loaded = False
+
+    def load(self):
+        """Load the native library and configure function signatures."""
+        lib_dir = os.path.dirname(os.path.abspath(self.lib_path))
+        logger.info(f"Loading SDK library from directory: {lib_dir}")
+
+        os_type = get_os_type()
+
+        if os_type == OS_TYPE_WINDOWS:
+            # On Windows, dependent DLLs (libwautils, libwaheap, etc.) must be
+            # findable. Add the directory to both PATH and via add_dll_directory.
+            existing_path = os.environ.get("PATH", "")
+            if lib_dir not in existing_path:
+                os.environ["PATH"] = lib_dir + ";" + existing_path
+                logger.info(f"Added {lib_dir} to PATH")
+
+            if hasattr(os, "add_dll_directory"):
+                os.add_dll_directory(lib_dir)
+                logger.info(f"Added DLL directory via os.add_dll_directory")
+
+            # Windows SDK uses __stdcall calling convention
+            self._lib = ctypes.WinDLL(self.lib_path)
+        else:
+            # On macOS/Linux, add library directory to search path so dependent
+            # libraries (libwautils, libwalocal, etc.) can be found.
+            env_var = "DYLD_LIBRARY_PATH" if os_type == OS_TYPE_MACOS else "LD_LIBRARY_PATH"
+            existing = os.environ.get(env_var, "")
+            if lib_dir not in existing:
+                os.environ[env_var] = lib_dir + (":" + existing if existing else "")
+            self._lib = ctypes.CDLL(self.lib_path)
+
+        # wa_api_setup(const wchar_t* json_config, wchar_t** json_out) -> int
+        self._lib.wa_api_setup.argtypes = [
+            ctypes.c_wchar_p,
+            ctypes.POINTER(ctypes.c_wchar_p)
+        ]
+        self._lib.wa_api_setup.restype = ctypes.c_int
+
+        # wa_api_invoke(const wchar_t* json_in, wchar_t** json_out) -> int
+        self._lib.wa_api_invoke.argtypes = [
+            ctypes.c_wchar_p,
+            ctypes.POINTER(ctypes.c_wchar_p)
+        ]
+        self._lib.wa_api_invoke.restype = ctypes.c_int
+
+        # wa_api_free(wchar_t* json_data) -> int
+        self._lib.wa_api_free.argtypes = [ctypes.c_wchar_p]
+        self._lib.wa_api_free.restype = ctypes.c_int
+
+        # wa_api_teardown() -> int
+        self._lib.wa_api_teardown.argtypes = []
+        self._lib.wa_api_teardown.restype = ctypes.c_int
+
+        self._loaded = True
+
+    def _call(self, func_name, json_in):
+        """Call an SDK function that takes json_in and returns json_out via pointer."""
+        if not self._loaded:
+            raise RuntimeError("SDK not loaded. Call load() first.")
+
+        logger.debug(f"{func_name} input: {json_in[:200]}")
+        func = getattr(self._lib, func_name)
+        json_out = ctypes.c_wchar_p()
+        rc = func(json_in, ctypes.byref(json_out))
+
+        result_str = None
+        if json_out.value is not None:
+            result_str = json_out.value
+            self._lib.wa_api_free(json_out)
+
+        return rc, result_str
+
+    def setup(self, license_cfg_path, pass_key_path, debug_log_path=None):
+        """Initialize the SDK with license configuration.
+
+        On Windows, only passkey_string is needed.
+        On Linux/macOS, license_bytes and license_key_bytes are also required.
+        """
+        # Read pass_key.txt
+        with open(pass_key_path, "r", encoding="utf-8") as f:
+            passkey = f.read().strip().replace("\r", "")
+
+        config = {
+            "passkey_string": passkey,
+            "enable_pretty_print": True,
+            "silent_mode": True,
+        }
+
+        os_type = get_os_type()
+
+        # Linux and macOS require the full license
+        if os_type in (OS_TYPE_LINUX, OS_TYPE_MACOS):
+            with open(license_cfg_path, "r", encoding="utf-8") as f:
+                license_data = json.load(f)
+            config["license_key_bytes"] = license_data["license_key"]
+            config["license_bytes"] = license_data["license"]
+            if os_type == OS_TYPE_MACOS:
+                config["restrict_bundle_search"] = (
+                    "user_home|shared_folder|removable_media|"
+                    "reminders|photos|calendars|contacts|music"
+                )
+        else:
+            # Windows: also works with just passkey, but include license if available
+            if os.path.isfile(license_cfg_path):
+                with open(license_cfg_path, "r", encoding="utf-8") as f:
+                    license_data = json.load(f)
+                config["license_key_bytes"] = license_data["license_key"]
+                config["license_bytes"] = license_data["license"]
+            config["online_mode"] = True
+
+        setup_json = {"config": config}
+        if debug_log_path:
+            setup_json["config_debug"] = {
+                "debug_log_level": "ALL",
+                "debug_log_output_path": debug_log_path,
+            }
+
+        json_str = json.dumps(setup_json)
+        rc, result_str = self._call("wa_api_setup", json_str)
+
+        if rc < 0:
+            raise SDKError("wa_api_setup", rc, result_str)
+
+        return json.loads(result_str) if result_str else {}
+
+    def invoke(self, method_id, **params):
+        """Call wa_api_invoke with the given method ID and parameters.
+
+        Returns (rc, parsed_json_response).
+        """
+        invoke_input = {"method": method_id}
+        # Normalize file paths to forward slashes for the SDK
+        for key, value in params.items():
+            if isinstance(value, str) and ("dat_input" in key or "path" in key):
+                params[key] = value.replace("\\", "/")
+        invoke_input.update(params)
+        json_str = json.dumps({"input": invoke_input})
+
+        rc, result_str = self._call("wa_api_invoke", json_str)
+
+        parsed = {}
+        if result_str:
+            try:
+                parsed = json.loads(result_str)
+            except json.JSONDecodeError:
+                parsed = {"raw": result_str}
+
+        return rc, parsed
+
+    def invokeJSON(self, json_in):
+        """Call wa_api_invoke with the given method ID and parameters.
+
+        Returns (rc, parsed_json_response).
+        """
+        json_str = json.dumps(json_in)
+        rc, result_str = self._call("wa_api_invoke", json_str)
+
+        parsed = {}
+        if result_str:
+            try:
+                parsed = json.loads(result_str)
+            except json.JSONDecodeError:
+                parsed = {"raw": result_str}
+
+        return rc, parsed
+
+
+    def teardown(self):
+        """Deinitialize the SDK."""
+        if not self._loaded:
+            return
+        rc = self._lib.wa_api_teardown()
+        if rc < 0:
+            raise SDKError("wa_api_teardown", rc)


### PR DESCRIPTION
…ment OS mapping

- helper/sdk_wrapper.py, copysdk.py, map_cve_to_kb.py, platform_utils.py: helper utilities for the python VAPM scanner (OESIS SDK wrapper/setup, SDK staging, CVE-to-KB mapping, platform helpers).
- centralized-assessment/map_ca_osdetails.py: updated OS details mapping.

Source only - the SDK binaries, license.cfg, download_token.txt and other secrets under helper/sdk/ are gitignored and excluded.