### PR TITLE
posture: compute Security Score via SDK method 111 instead of manual …

### DIFF
--- a/tools/posture/src/OPSWAT-Adapter/Tasks/TaskSecurityScore.cs
+++ b/tools/posture/src/OPSWAT-Adapter/Tasks/TaskSecurityScore.cs
@@ -141,42 +141,55 @@ namespace OPSWAT_Adapter.Tasks
 
         public int GetSecurityScore()
         {
-            int resultCount = 0;
+            int totalScore = 0;
 
             OESISFramework.InitializeFramework();
-
-            List<int> firewallProducts = Util.GetProductSignaturesByCategory(OESISCategory.FIREWALL, GetProductList());
-            if (IsFirewallRunning(firewallProducts))
+            try
             {
-                resultCount += 2;
+                // Ask the SDK to calculate the OPSWAT Security Score directly
+                // (WAAPI_MID_GET_SECURITY_SCORE, method 111) instead of summing individual checks.
+                // force_refresh makes the engine refresh the underlying security status rather
+                // than using cached values.
+                string json_in = "{\"input\": { \"method\": 111, \"force_refresh\": true } }";
+                string json_out = "";
+                int callResult = OESISFramework.Invoke(json_in, out json_out);
+
+                if (callResult < 0)
+                {
+                    GetLogger().Log(false, "Security Score: SDK call failed (rc=" + callResult + ")");
+                    return 0;
+                }
+
+                JObject parsed = JObject.Parse(json_out);
+                JToken result = parsed["result"];
+
+                // total_score is on a 0-100 scale.
+                totalScore = (int)result["total_score"];
+                string scoreStatus = (string)result["score_status"];
+                GetLogger().Log(scoreStatus == "good",
+                    "OPSWAT Security Score: " + totalScore + " / 100 (" + scoreStatus + ")");
+
+                // Log the per-category breakdown so the tab shows where the score came from.
+                JToken categories = result["categories"];
+                if (categories != null)
+                {
+                    foreach (JToken category in categories)
+                    {
+                        string name = (string)category["name"];
+                        int score = (int)category["score"];
+                        int maxScore = (int)category["max_score"];
+                        string status = (string)category["status"];
+                        GetLogger().Log(status == "good",
+                            name + ": " + score + " / " + maxScore + " (" + status + ")");
+                    }
+                }
+            }
+            finally
+            {
+                OESISFramework.TearDown();
             }
 
-            List<int> encryptionProducts = Util.GetProductSignaturesByCategory(OESISCategory.DISK_ENCRYPTION, GetProductList());
-            if (IsDiskEncrypted(encryptionProducts))
-            {
-                resultCount += 2;
-            }
-
-            List<int> antimalwareProducts = Util.GetProductSignaturesByCategory(OESISCategory.ANTIMALWARE, GetProductList());
-            if (IsAntimalwareProtected(antimalwareProducts))
-            {
-                resultCount += 2;
-            }
-
-            if (IsUpdateDefinitionRecent(antimalwareProducts, DateTime.Now.AddDays(-1)))
-            {
-                resultCount += 2;
-            }
-
-            if (IsScanRecent(antimalwareProducts, DateTime.Now.AddDays(-1)))
-            {
-                resultCount += 2;
-            }
-
-
-            OESISFramework.TearDown();
-
-            return resultCount;
+            return totalScore;
         }
 
     }

--- a/tools/posture/src/opswat-posture/MainForm.Designer.cs
+++ b/tools/posture/src/opswat-posture/MainForm.Designer.cs
@@ -496,10 +496,12 @@ namespace OPSWATPosture
             // tbSecurityScore
             // 
             this.tbSecurityScore.Location = new System.Drawing.Point(9, 64);
+            this.tbSecurityScore.Maximum = 100;
+            this.tbSecurityScore.TickFrequency = 10;
             this.tbSecurityScore.Name = "tbSecurityScore";
             this.tbSecurityScore.Size = new System.Drawing.Size(310, 45);
             this.tbSecurityScore.TabIndex = 6;
-            this.tbSecurityScore.Value = 5;
+            this.tbSecurityScore.Value = 70;
             this.tbSecurityScore.Scroll += new System.EventHandler(this.tbSecurityScore_Scroll);
             // 
             // btnGetSecurityScore


### PR DESCRIPTION
…point-summing

- TaskSecurityScore.GetSecurityScore() now calls the SDK's WAAPI_MID_GET_SECURITY_SCORE (method 111) with force_refresh, returning the engine's total_score (0-100) and logging the per-category breakdown (score_status + each category's score/max/status). Wrapped in try/finally so the framework tears down on error. This replaces the manual firewall/ encryption/antimalware/definition/scan point-summing, which credited protection that was not installed (empty product list defaulted to "compliant").
- MainForm.Designer.cs: rescale the configured-score trackbar from the default 0-10 to 0-100 (Maximum=100, TickFrequency=10, default 70) to match the SDK score scale.